### PR TITLE
Fix arm64 build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,10 @@ jobs:
                   fi
             - name: Checkout
               uses: actions/checkout@v2
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
             - name: Login to DockerHub
               uses: docker/login-action@v3
               with:


### PR DESCRIPTION
Hi,

this PR adds the `docker/setup-qemu-action@v3` and `docker/setup-buildx-action@v3` actions to enable `arm64` builds.

Regards