### PR TITLE
Fix Table Item Truncation issue

### DIFF
--- a/resources/scripts/admin/views/customers/Index.vue
+++ b/resources/scripts/admin/views/customers/Index.vue
@@ -152,13 +152,11 @@
           <router-link :to="{ path: `customers/${row.data.id}/view` }">
             <BaseText
               :text="row.data.name"
-              :length="30"
               tag="span"
               class="font-medium text-primary-500 flex flex-col"
             />
             <BaseText
               :text="row.data.contact_name ? row.data.contact_name : ''"
-              :length="30"
               tag="span"
               class="text-xs text-gray-400"
             />

--- a/resources/scripts/admin/views/customers/partials/CustomerViewSidebar.vue
+++ b/resources/scripts/admin/views/customers/partials/CustomerViewSidebar.vue
@@ -133,7 +133,6 @@
           <div>
             <BaseText
               :text="customer.name"
-              :length="30"
               class="
                 pr-2
                 text-sm
@@ -149,7 +148,6 @@
             <BaseText
               v-if="customer.contact_name"
               :text="customer.contact_name"
-              :length="30"
               class="
                 mt-1
                 text-xs

--- a/resources/scripts/admin/views/estimates/Index.vue
+++ b/resources/scripts/admin/views/estimates/Index.vue
@@ -211,7 +211,7 @@
         </template>
 
         <template #cell-name="{ row }">
-          <BaseText :text="row.data.customer.name" :length="30" />
+          <BaseText :text="row.data.customer.name" />
         </template>
 
         <template #cell-status="{ row }">

--- a/resources/scripts/admin/views/estimates/View.vue
+++ b/resources/scripts/admin/views/estimates/View.vue
@@ -180,7 +180,6 @@
             <div class="flex-2">
               <BaseText
                 :text="estimate.customer.name"
-                :length="30"
                 class="
                   pr-2
                   mb-2

--- a/resources/scripts/admin/views/expenses/Index.vue
+++ b/resources/scripts/admin/views/expenses/Index.vue
@@ -191,7 +191,6 @@
         <template #cell-user_name="{ row }">
           <BaseText
             :text="row.data.customer ? row.data.customer.name : '-'"
-            :length="30"
           />
         </template>
 

--- a/resources/scripts/admin/views/invoices/Index.vue
+++ b/resources/scripts/admin/views/invoices/Index.vue
@@ -196,7 +196,7 @@
         </template>
 
         <template #cell-name="{ row }">
-          <BaseText :text="row.data.customer.name" :length="30" />
+          <BaseText :text="row.data.customer.name" />
         </template>
 
         <!-- Invoice Number  -->

--- a/resources/scripts/admin/views/invoices/View.vue
+++ b/resources/scripts/admin/views/invoices/View.vue
@@ -423,7 +423,6 @@ onSearched = debounce(onSearched, 500)
             <div class="flex-2">
               <BaseText
                 :text="invoice.customer.name"
-                :length="30"
                 class="
                   pr-2
                   mb-2

--- a/resources/scripts/admin/views/items/Index.vue
+++ b/resources/scripts/admin/views/items/Index.vue
@@ -155,7 +155,7 @@
             :to="{ path: `items/${row.data.id}/edit` }"
             class="font-medium text-primary-500"
           >
-            {{ row.data.name }}
+            <BaseText :text="row.data.name" />
           </router-link>
         </template>
 

--- a/resources/scripts/admin/views/modules/partials/ModuleCard.vue
+++ b/resources/scripts/admin/views/modules/partials/ModuleCard.vue
@@ -86,7 +86,6 @@
       <base-text
         :text="data.short_description"
         class="pt-4 text-gray-500 h-16 line-clamp-2"
-        :length="110"
       >
       </base-text>
       <div

--- a/resources/scripts/admin/views/payments/Index.vue
+++ b/resources/scripts/admin/views/payments/Index.vue
@@ -165,7 +165,7 @@
         </template>
 
         <template #cell-name="{ row }">
-          <BaseText :text="row.data.customer.name" :length="30" tag="span" />
+          <BaseText :text="row.data.customer.name" tag="span" />
         </template>
 
         <template #cell-payment_mode="{ row }">

--- a/resources/scripts/admin/views/payments/View.vue
+++ b/resources/scripts/admin/views/payments/View.vue
@@ -158,7 +158,6 @@
             <div class="flex-2">
               <BaseText
                 :text="payment?.customer?.name"
-                :length="30"
                 class="
                   pr-2
                   mb-2

--- a/resources/scripts/admin/views/recurring-invoices/Index.vue
+++ b/resources/scripts/admin/views/recurring-invoices/Index.vue
@@ -201,7 +201,6 @@
           <router-link :to="{ path: `recurring-invoices/${row.data.id}/view` }">
             <BaseText
               :text="row.data.customer.name"
-              :length="30"
               tag="span"
               class="font-medium text-primary-500 flex flex-col"
             />
@@ -212,7 +211,6 @@
                   ? row.data.customer.contact_name
                   : ''
               "
-              :length="30"
               tag="span"
               class="text-xs text-gray-400"
             />

--- a/resources/scripts/admin/views/recurring-invoices/partials/RecurringInvoiceViewSidebar.vue
+++ b/resources/scripts/admin/views/recurring-invoices/partials/RecurringInvoiceViewSidebar.vue
@@ -262,7 +262,6 @@ onSearched = debounce(onSearched, 500)
           <div class="flex-2">
             <BaseText
               :text="invoice.customer.name"
-              :length="30"
               class="
                 pr-2
                 mb-2

--- a/resources/scripts/components/base/BaseCustomerSelectPopup.vue
+++ b/resources/scripts/components/base/BaseCustomerSelectPopup.vue
@@ -26,7 +26,6 @@
       <div class="flex relative justify-between mb-2">
         <BaseText
           :text="selectedCustomer.name"
-          :length="30"
           class="flex-1 text-base font-medium text-left text-gray-900"
         />
         <div class="flex">
@@ -308,7 +307,6 @@
                     <BaseText
                       v-if="customer.name"
                       :text="customer.name"
-                      :length="30"
                       class="
                         m-0
                         text-base
@@ -320,7 +318,6 @@
                     <BaseText
                       v-if="customer.contact_name"
                       :text="customer.contact_name"
-                      :length="30"
                       class="
                         m-0
                         text-sm

--- a/resources/scripts/components/base/BaseText.vue
+++ b/resources/scripts/components/base/BaseText.vue
@@ -1,9 +1,10 @@
 <template>
-  <BaseCustomTag :tag="tag" :title="text">
-    {{ displayText }}
-  </BaseCustomTag>
+  <div class="whitespace-normal">
+    <BaseCustomTag :tag="tag" :title="text" class="line-clamp-1">
+      {{ displayText }}
+    </BaseCustomTag>
+  </div>
 </template>
-
 <script setup>
 import { computed } from "vue"
 
@@ -20,12 +21,17 @@ const props = defineProps({
 
   length: {
     type: Number,
-    default: 0,
+    default: null,
   }
 })
 
-const displayText = computed(() => {
+const { text, length } = props;
 
-  return props.text.length < props.length ?  props.text : `${props.text.substring(0 , props.length)}...`
-})
+const displayText = computed(() => {
+  if (length) {
+    return text.length <= length ? text : `${text.substring(0, length)}...`;
+  }
+  return text;
+});
+
 </script>


### PR DESCRIPTION
Issue #88

- Used the tailwind line-clamp class in BaseText component.
- Removed the defined fixed lengths
- Set default length as null and if a value is passed force truncate text