### PR TITLE
Dotenv updater command

### DIFF
--- a/app/Console/Commands/UpdateDotEnv.php
+++ b/app/Console/Commands/UpdateDotEnv.php
@@ -2,10 +2,9 @@
 
 namespace App\Console\Commands;
 
+use App\Space\EnvironmentManager;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\File;
-use Illuminate\Support\Str;
 
 class UpdateDotEnv extends Command
 {
@@ -28,27 +27,23 @@ class UpdateDotEnv extends Command
      */
     public function handle()
     {
-        try {
-            $this->updateEnvFile([
-                'APP_TIMEZONE' => config('app.timezone') ?? 'UTC',
+        $environmentManager = new EnvironmentManager();
 
+        try {
+            $environmentManager->updateEnv([
+                'APP_TIMEZONE' => config('app.timezone') ?? 'UTC',
                 'APP_LOCALE' => config('app.locale') ?? 'en',
                 'APP_FALLBACK_LOCALE' => config('app.fallback_locale') ?? 'en',
                 'APP_FAKER_LOCALE' => config('app.faker_locale') ?? 'en_US',
-
                 'LOG_STACK' => 'single',
-
                 'SESSION_ENCRYPT' => 'false',
                 'SESSION_PATH' => '/',
                 'SESSION_DOMAIN' => 'null',
-
                 'BROADCAST_CONNECTION' => 'log',
                 'FILESYSTEM_DISK' => 'local',
                 'QUEUE_CONNECTION' => 'sync',
-
                 'CACHE_STORE' => 'file',
                 'CACHE_PREFIX' => '',
-
                 'REDIS_CLIENT' => 'phpredis',
             ]);
 
@@ -61,54 +56,5 @@ class UpdateDotEnv extends Command
 
         $this->info('Configuration cached successfully.');
 
-    }
-
-    /**
-     * Update the .env file with the provided data.
-     *
-     * @throws \Exception
-     */
-    private function updateEnvFile(array $data): void
-    {
-        $envFile = base_path('.env');
-
-        if (! File::exists($envFile)) {
-            throw new \Exception('The .env file does not exist.');
-        }
-
-        // Read the contents of the .env file
-        $contents = File::get($envFile);
-
-        // Split the contents into an array of lines
-        $lines = explode("\n", $contents);
-
-        // Loop through the lines and update the values
-        foreach ($lines as &$line) {
-            if (empty($line) || Str::startsWith($line, '#')) {
-                continue;
-            }
-
-            // Split each line into key and value
-            $parts = explode('=', $line, 2);
-            $key = $parts[0];
-
-            // Check if the key exists in the provided data
-            if (isset($data[$key])) {
-                // Update the value
-                $line = $key.'='.$data[$key];
-                unset($data[$key]);
-            }
-        }
-
-        // Append any new keys that were not present in the original file
-        foreach ($data as $key => $value) {
-            $lines[] = $key.'='.$value;
-        }
-
-        // Combine the lines back into a string
-        $updatedContents = implode("\n", $lines);
-
-        // Write the updated contents back to the .env file
-        File::put($envFile, $updatedContents);
     }
 }

--- a/app/Console/Commands/UpdateDotEnv.php
+++ b/app/Console/Commands/UpdateDotEnv.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class UpdateDotEnv extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'core:update-dot-env';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update the .env file keys for Laravel 11';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        try {
+            $this->updateEnvFile([
+                'APP_TIMEZONE' => config('app.timezone') ?? 'UTC',
+
+                'APP_LOCALE' => config('app.locale') ?? 'en',
+                'APP_FALLBACK_LOCALE' => config('app.fallback_locale') ?? 'en',
+                'APP_FAKER_LOCALE' => config('app.faker_locale') ?? 'en_US',
+
+                'LOG_STACK' => 'single',
+
+                'SESSION_ENCRYPT' => 'false',
+                'SESSION_PATH' => '/',
+                'SESSION_DOMAIN' => 'null',
+
+                'BROADCAST_CONNECTION' => 'log',
+                'FILESYSTEM_DISK' => 'local',
+                'QUEUE_CONNECTION' => 'sync',
+
+                'CACHE_STORE' => 'file',
+                'CACHE_PREFIX' => '',
+
+                'REDIS_CLIENT' => 'phpredis',
+            ]);
+
+            $this->info('The .env file has been updated successfully.');
+        } catch (\Exception $e) {
+            $this->error('Failed to update the .env file: '.$e->getMessage());
+        }
+
+        Artisan::call('config:cache');
+
+        $this->info('Configuration cached successfully.');
+
+    }
+
+    /**
+     * Update the .env file with the provided data.
+     *
+     * @throws \Exception
+     */
+    private function updateEnvFile(array $data): void
+    {
+        $envFile = base_path('.env');
+
+        if (! File::exists($envFile)) {
+            throw new \Exception('The .env file does not exist.');
+        }
+
+        // Read the contents of the .env file
+        $contents = File::get($envFile);
+
+        // Split the contents into an array of lines
+        $lines = explode("\n", $contents);
+
+        // Loop through the lines and update the values
+        foreach ($lines as &$line) {
+            if (empty($line) || Str::startsWith($line, '#')) {
+                continue;
+            }
+
+            // Split each line into key and value
+            $parts = explode('=', $line, 2);
+            $key = $parts[0];
+
+            // Check if the key exists in the provided data
+            if (isset($data[$key])) {
+                // Update the value
+                $line = $key.'='.$data[$key];
+                unset($data[$key]);
+            }
+        }
+
+        // Append any new keys that were not present in the original file
+        foreach ($data as $key => $value) {
+            $lines[] = $key.'='.$value;
+        }
+
+        // Combine the lines back into a string
+        $updatedContents = implode("\n", $lines);
+
+        // Write the updated contents back to the .env file
+        File::put($envFile, $updatedContents);
+    }
+}


### PR DESCRIPTION
A new command to automatically update the .env file.

```bash
php artisan core:update-dot-env
```

This command allows you to stick to the latest laravel changes to this file since Laravel 11 :
https://github.com/laravel/laravel/compare/10.x...11.x#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c

It remains to be defined whether this command should be documented to help users perform the update, or whether it should be integrated into the automatic update process.


In my opinion, it's better to let users run this command. Even if the process is fairly safe, it's impossible to know what users have done with their environment file and it also allows them to make a copy before running the command.