### PR TITLE
Adding cache and queue tables migrations

### DIFF
--- a/database/migrations/2020_05_12_154129_add_user_id_to_expenses_table.php
+++ b/database/migrations/2020_05_12_154129_add_user_id_to_expenses_table.php
@@ -20,8 +20,5 @@ return new class extends Migration
     /**
      * Reverse the migrations.
      */
-    public function down(): void
-    {
-
-    }
+    public function down(): void {}
 };

--- a/database/migrations/2020_05_12_154129_add_user_id_to_expenses_table.php
+++ b/database/migrations/2020_05_12_154129_add_user_id_to_expenses_table.php
@@ -20,5 +20,8 @@ return new class extends Migration
     /**
      * Reverse the migrations.
      */
-    public function down(): void {}
+    public function down(): void
+    {
+
+    }
 };

--- a/database/migrations/2024_07_17_113642_create_cache_table.php
+++ b/database/migrations/2024_07_17_113642_create_cache_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cache', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->mediumText('value');
+            $table->integer('expiration');
+        });
+
+        Schema::create('cache_locks', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->string('owner');
+            $table->integer('expiration');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cache');
+        Schema::dropIfExists('cache_locks');
+    }
+};

--- a/database/migrations/2024_07_17_113702_create_jobs_table.php
+++ b/database/migrations/2024_07_17_113702_create_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('jobs');
+    }
+};


### PR DESCRIPTION
To prevent any issue when users wants to switch to `CACHE_STORE=database` and `QUEUE_CONNECTION=database` we create the migrations by default even if they are not used.