### PR TITLE
Add VAT and Tax into PDF Trait

### DIFF
--- a/app/Traits/GeneratesPdfTrait.php
+++ b/app/Traits/GeneratesPdfTrait.php
@@ -140,6 +140,8 @@ trait GeneratesPdfTrait
             '{COMPANY_ADDRESS_STREET_2}' => $companyAddress->address_street_2,
             '{COMPANY_PHONE}' => $companyAddress->phone,
             '{COMPANY_ZIP_CODE}' => $companyAddress->zip,
+            '{COMPANY_VAT}' => $this->company->vat_id,
+            '{COMPANY_TAX}' => $this->company->tax_id,
             '{CONTACT_DISPLAY_NAME}' => $customer->name,
             '{PRIMARY_CONTACT_NAME}' => $customer->contact_name,
             '{CONTACT_EMAIL}' => $customer->email,

--- a/resources/scripts/components/base/BaseCustomInput.vue
+++ b/resources/scripts/components/base/BaseCustomInput.vue
@@ -248,6 +248,8 @@ async function getFields() {
           { label: 'Address Street 2', value: 'COMPANY_ADDRESS_STREET_2' },
           { label: 'Phone', value: 'COMPANY_PHONE' },
           { label: 'Zip Code', value: 'COMPANY_ZIP_CODE' },
+          { label: 'Vat Id', value: 'COMPANY_VAT' },
+          { label: 'Tax Id', value: 'COMPANY_TAX' },
         ],
       })
     }


### PR DESCRIPTION
Hi,

I would like to use the VAT and TAX id in my invoice due to French regulations on invoices, but not possible at the moment.

This PR adds VAT and TAX id in the Pdf Trait and vue component 

