### PR TITLE
Fix long text on dropdown items

### DIFF
--- a/resources/scripts/components/base/BaseDropdownItem.vue
+++ b/resources/scripts/components/base/BaseDropdownItem.vue
@@ -4,7 +4,7 @@
       href="#"
       :class="[
         active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
-        'group flex items-center px-4 py-2 text-sm font-normal',
+        'group flex items-center px-4 py-2 text-sm font-normal whitespace-normal',
       ]"
     >
       <slot :active="active" />


### PR DESCRIPTION
![Capture d’écran 2024-09-25 à 16 55 01](https://github.com/user-attachments/assets/5cbbb774-0a89-4402-8fd0-a70401513e20)

Sometimes, when the translated text was too long, the icon would get compressed and very small because the text didn't wrap. Now, if the text exceeds the defined size of the dropdown element, it wraps to the next line (white-space).

![Capture d’écran 2024-09-25 à 16 57 50](https://github.com/user-attachments/assets/06b114df-9f56-4c33-a9ef-53db4e2a05f8)
