### PR TITLE
Include a Tax ID field in both customer creation and invoices

### DIFF
--- a/app/Http/Requests/CustomerRequest.php
+++ b/app/Http/Requests/CustomerRequest.php
@@ -49,8 +49,10 @@ class CustomerRequest extends FormRequest
             'prefix' => [
                 'nullable',
             ],
+            'tax_id' => [
+                'nullable',
+            ],
             'enable_portal' => [
-
                 'boolean',
             ],
             'currency_id' => [
@@ -133,6 +135,7 @@ class CustomerRequest extends FormRequest
                 'password',
                 'phone',
                 'prefix',
+                'tax_id',
                 'company_name',
                 'contact_name',
                 'website',

--- a/app/Http/Resources/Customer/CustomerResource.php
+++ b/app/Http/Resources/Customer/CustomerResource.php
@@ -30,6 +30,7 @@ class CustomerResource extends JsonResource
             'formatted_created_at' => $this->formattedCreatedAt,
             'avatar' => $this->avatar,
             'prefix' => $this->prefix,
+            'tax_id' => $this->tax_id,
             'billing' => $this->when($this->billingAddress()->exists(), function () {
                 return new AddressResource($this->billingAddress);
             }),

--- a/app/Http/Resources/CustomerResource.php
+++ b/app/Http/Resources/CustomerResource.php
@@ -35,6 +35,7 @@ class CustomerResource extends JsonResource
             'due_amount' => $this->due_amount,
             'base_due_amount' => $this->base_due_amount,
             'prefix' => $this->prefix,
+            'tax_id' => $this->tax_id,
             'billing' => $this->when($this->billingAddress()->exists(), function () {
                 return new AddressResource($this->billingAddress);
             }),

--- a/app/Traits/GeneratesPdfTrait.php
+++ b/app/Traits/GeneratesPdfTrait.php
@@ -145,6 +145,7 @@ trait GeneratesPdfTrait
             '{CONTACT_EMAIL}' => $customer->email,
             '{CONTACT_PHONE}' => $customer->phone,
             '{CONTACT_WEBSITE}' => $customer->website,
+            '{CONTACT_TAX_ID}' => __('pdf_tax_id').': '.$customer->tax_id,
         ];
 
         $customFields = $this->fields;

--- a/database/migrations/2024_10_04_093723_add_tax_id_field_to_customers_table.php
+++ b/database/migrations/2024_10_04_093723_add_tax_id_field_to_customers_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('customers', function (Blueprint $table) {
+            $table->string('tax_id')->nullable()->after('github_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('customers', function (Blueprint $table) {
+            $table->dropColumn('tax_id');
+        });
+    }
+};

--- a/lang/en.json
+++ b/lang/en.json
@@ -172,6 +172,7 @@
   "customers": {
     "title": "Customers",
     "prefix": "Prefix",
+    "tax_id": "Tax ID",
     "add_customer": "Add Customer",
     "contacts_list": "Customer List",
     "name": "Name",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite --host",
+    "dev": "vite",
     "build": "vite build",
     "serve": "vite preview",
     "test": "eslint ./resources/scripts --ext .js,.vue"

--- a/resources/scripts/admin/components/modal-components/CustomerModal.vue
+++ b/resources/scripts/admin/components/modal-components/CustomerModal.vue
@@ -116,6 +116,15 @@
                   />
                 </BaseInputGroup>
               </BaseInputGrid>
+
+              <BaseInputGroup :label="$t('customers.tax_id')">
+                <BaseInput
+                  v-model="customerStore.currentCustomer.tax_id"
+                  type="text"
+                  class="mt-1 md:mt-0"
+                />
+              </BaseInputGroup>
+
             </BaseInputGrid>
           </BaseTab>
 

--- a/resources/scripts/admin/views/customers/Create.vue
+++ b/resources/scripts/admin/views/customers/Create.vue
@@ -157,6 +157,24 @@
                 @input="v$.currentCustomer.prefix.$touch()"
               />
             </BaseInputGroup>
+
+            <BaseInputGroup
+              :label="$t('customers.tax_id')"
+              :error="
+                v$.currentCustomer.tax_id.$error &&
+                v$.currentCustomer.tax_id.$errors[0].$message
+              "
+              :content-loading="isFetchingInitialData"
+            >
+              <BaseInput
+                v-model="customerStore.currentCustomer.tax_id"
+                :content-loading="isFetchingInitialData"
+                type="text"
+                name="tax_id"
+                :invalid="v$.currentCustomer.tax_id.$error"
+                @input="v$.currentCustomer.tax_id.$touch()"
+              />
+            </BaseInputGroup>
           </BaseInputGrid>
         </div>
 
@@ -644,6 +662,9 @@ const rules = computed(() => {
           t('validation.name_min_length', { count: 3 }),
           minLength(3)
         ),
+      },
+      tax_id: {
+        required: helpers.withMessage(t('validation.required'), required),
       },
       currency_id: {
         required: helpers.withMessage(t('validation.required'), required),

--- a/resources/scripts/components/base/BaseCustomInput.vue
+++ b/resources/scripts/components/base/BaseCustomInput.vue
@@ -180,6 +180,7 @@ async function getFields() {
           { label: 'Email', value: 'CONTACT_EMAIL' },
           { label: 'Phone', value: 'CONTACT_PHONE' },
           { label: 'Website', value: 'CONTACT_WEBSITE' },
+          { label: 'Tax ID', value: 'CONTACT_TAX_ID' },
           ...customerFields.value.map((i) => ({
             label: i.label,
             value: i.slug,

--- a/resources/scripts/main.js
+++ b/resources/scripts/main.js
@@ -14,8 +14,7 @@ import.meta.glob([
 
 window.pinia = pinia
 window.Vuelidate = Vuelidate
-
-import InvoiceShelf from './InvoiceShelf'
+import InvoiceShelf from './InvoiceShelf.js'
 
 window.Vue = Vue
 window.router = router

--- a/vite.config.js
+++ b/vite.config.js
@@ -32,11 +32,8 @@ export default defineConfig({
                 },
             },
         }),
-        laravel({
-            input: [
-                'resources/scripts/main.js',
-            ],
-            refresh: true,
-        })
+        laravel([
+            'resources/scripts/main.js'
+        ])
     ]
 });


### PR DESCRIPTION
Closes https://github.com/InvoiceShelf/InvoiceShelf/issues/133

This PR allows to set a tax id for customers and display it in invoices and estimates.

![Capture d’écran 2024-10-04 à 12 11 19](https://github.com/user-attachments/assets/d5b16a3b-74dc-4f00-bb2b-e4bf8c76edbd)

![Capture d’écran 2024-10-04 à 12 11 41](https://github.com/user-attachments/assets/29ce83d0-6b4f-48b6-bf2a-c27f2632cc94)

![Capture d’écran 2024-10-04 à 12 12 00](https://github.com/user-attachments/assets/4367be50-eecc-4df3-9dd9-49b21f9e6373)
