### PR TITLE
Support for Zero and Negative Item Quantities on Invoices

### DIFF
--- a/app/Http/Requests/InvoicesRequest.php
+++ b/app/Http/Requests/InvoicesRequest.php
@@ -49,11 +49,10 @@ class InvoicesRequest extends FormRequest
                 'required',
             ],
             'sub_total' => [
-                'integer',
+                'numeric',
                 'required',
             ],
             'total' => [
-                'integer',
                 'numeric',
                 'max:999999999999',
                 'required',
@@ -83,7 +82,7 @@ class InvoicesRequest extends FormRequest
                 'required',
             ],
             'items.*.price' => [
-                'integer',
+                'numeric',
                 'required',
             ],
         ];

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -393,7 +393,7 @@ class Invoice extends Model implements HasMedia
             return 'customer_cannot_be_changed_after_payment_is_added';
         }
 
-        if ($request->total < $total_paid_amount) {
+        if ($request->total >= 0 && $request->total < $total_paid_amount) {
             return 'total_invoice_amount_must_be_more_than_paid_amount';
         }
 

--- a/database/migrations/2024_10_09_103306_modify_invoices_to_allow_negative_values.php
+++ b/database/migrations/2024_10_09_103306_modify_invoices_to_allow_negative_values.php
@@ -19,19 +19,19 @@ return new class extends Migration
             $table->bigInteger('tax')->change();
             $table->bigInteger('due_amount')->change();
             $table->bigInteger('base_discount_val')->nullable()->change();
-            $table->bigInteger('base_sub_total')->change();
-            $table->bigInteger('base_total')->change();
-            $table->bigInteger('base_tax')->change();
-            $table->bigInteger('base_due_amount')->change();
+            $table->bigInteger('base_sub_total')->nullable()->change();
+            $table->bigInteger('base_total')->nullable()->change();
+            $table->bigInteger('base_tax')->nullable()->change();
+            $table->bigInteger('base_due_amount')->nullable()->change();
         });
 
         Schema::table('invoice_items', function (Blueprint $table) {
             $table->bigInteger('discount_val')->change();
             $table->bigInteger('tax')->change();
             $table->bigInteger('total')->change();
-            $table->bigInteger('base_discount_val')->change();
-            $table->bigInteger('base_tax')->change();
-            $table->bigInteger('base_total')->change();
+            $table->bigInteger('base_discount_val')->nullable()->change();
+            $table->bigInteger('base_tax')->nullable()->change();
+            $table->bigInteger('base_total')->nullable()->change();
         });
     }
 
@@ -47,19 +47,19 @@ return new class extends Migration
             $table->unsignedBigInteger('total')->change();
             $table->unsignedBigInteger('due_amount')->change();
             $table->unsignedBigInteger('base_discount_val')->nullable()->change();
-            $table->unsignedBigInteger('base_sub_total')->change();
-            $table->unsignedBigInteger('base_total')->change();
-            $table->unsignedBigInteger('base_tax')->change();
-            $table->unsignedBigInteger('base_due_amount')->change();
+            $table->unsignedBigInteger('base_sub_total')->nullable()->change();
+            $table->unsignedBigInteger('base_total')->nullable()->change();
+            $table->unsignedBigInteger('base_tax')->nullable()->change();
+            $table->unsignedBigInteger('base_due_amount')->nullable()->change();
         });
 
         Schema::table('invoice_items', function (Blueprint $table) {
             $table->unsignedBigInteger('discount_val')->change();
             $table->unsignedBigInteger('tax')->change();
             $table->unsignedBigInteger('total')->change();
-            $table->unsignedBigInteger('base_discount_val')->change();
-            $table->unsignedBigInteger('base_tax')->change();
-            $table->unsignedBigInteger('base_total')->change();
+            $table->unsignedBigInteger('base_discount_val')->nullable()->change();
+            $table->unsignedBigInteger('base_tax')->nullable()->change();
+            $table->unsignedBigInteger('base_total')->nullable()->change();
         });
     }
 };

--- a/database/migrations/2024_10_09_103306_modify_invoices_to_allow_negative_values.php
+++ b/database/migrations/2024_10_09_103306_modify_invoices_to_allow_negative_values.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->bigInteger('discount_val')->nullable()->change();
+            $table->bigInteger('sub_total')->change();
+            $table->bigInteger('total')->change();
+            $table->bigInteger('tax')->change();
+            $table->bigInteger('due_amount')->change();
+            $table->bigInteger('base_discount_val')->nullable()->change();
+            $table->bigInteger('base_sub_total')->change();
+            $table->bigInteger('base_total')->change();
+            $table->bigInteger('base_tax')->change();
+            $table->bigInteger('base_due_amount')->change();
+        });
+
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table->bigInteger('discount_val')->change();
+            $table->bigInteger('tax')->change();
+            $table->bigInteger('total')->change();
+            $table->bigInteger('base_discount_val')->change();
+            $table->bigInteger('base_tax')->change();
+            $table->bigInteger('base_total')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->unsignedBigInteger('discount_val')->nullable()->change();
+            $table->unsignedBigInteger('sub_total')->change();
+            $table->unsignedBigInteger('total')->change();
+            $table->unsignedBigInteger('due_amount')->change();
+            $table->unsignedBigInteger('base_discount_val')->nullable()->change();
+            $table->unsignedBigInteger('base_sub_total')->change();
+            $table->unsignedBigInteger('base_total')->change();
+            $table->unsignedBigInteger('base_tax')->change();
+            $table->unsignedBigInteger('base_due_amount')->change();
+        });
+
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table->unsignedBigInteger('discount_val')->change();
+            $table->unsignedBigInteger('tax')->change();
+            $table->unsignedBigInteger('total')->change();
+            $table->unsignedBigInteger('base_discount_val')->change();
+            $table->unsignedBigInteger('base_tax')->change();
+            $table->unsignedBigInteger('base_total')->change();
+        });
+    }
+};

--- a/resources/scripts/admin/components/estimate-invoice-common/CreateItemRow.vue
+++ b/resources/scripts/admin/components/estimate-invoice-common/CreateItemRow.vue
@@ -42,7 +42,6 @@
                 :content-loading="loading"
                 type="number"
                 small
-                min="0"
                 step="any"
                 @change="syncItemToStore()"
                 @input="v$.quantity.$touch()"
@@ -325,10 +324,6 @@ const rules = {
   },
   quantity: {
     required: helpers.withMessage(t('validation.required'), required),
-    minValue: helpers.withMessage(
-      t('validation.qty_must_greater_than_zero'),
-      minValue(0)
-    ),
     maxLength: helpers.withMessage(
       t('validation.amount_maxlength'),
       maxLength(20)
@@ -336,10 +331,6 @@ const rules = {
   },
   price: {
     required: helpers.withMessage(t('validation.required'), required),
-    minValue: helpers.withMessage(
-      t('validation.number_length_minvalue'),
-      minValue(1)
-    ),
     maxLength: helpers.withMessage(
       t('validation.price_maxlength'),
       maxLength(20)
@@ -350,7 +341,7 @@ const rules = {
       t('validation.discount_maxlength'),
       between(
         0,
-        computed(() => subtotal.value)
+        computed(() => Math.abs(subtotal.value))
       )
     ),
   },
@@ -403,11 +394,12 @@ function updateTax(data) {
 
 function setDiscount() {
   const newValue = props.store[props.storeProp].items[props.index].discount
+  const absoluteSubtotal = Math.abs(subtotal.value)
 
   if (props.itemData.discount_type === 'percentage'){
-    updateItemAttribute('discount_val', Math.round((subtotal.value * newValue) / 100))
-  }else{
-    updateItemAttribute('discount_val', Math.round(newValue * 100))
+    updateItemAttribute('discount_val', Math.round((absoluteSubtotal * newValue) / 100))
+  } else {
+    updateItemAttribute('discount_val', Math.min(Math.round(newValue * 100), absoluteSubtotal))
   }
 }
 

--- a/resources/scripts/admin/views/invoices/create/InvoiceCreate.vue
+++ b/resources/scripts/admin/views/invoices/create/InvoiceCreate.vue
@@ -254,6 +254,7 @@ async function submitForm() {
   v$.value.$touch()
 
   if (v$.value.$invalid) {
+    console.log('Form is invalid:', v$.value.$errors)
     return false
   }
 

--- a/tests/Feature/Admin/EstimateTest.php
+++ b/tests/Feature/Admin/EstimateTest.php
@@ -231,13 +231,20 @@ test('estimate mark as rejected', function () {
 });
 
 test('create invoice from estimate', function () {
-    $estimate = Estimate::factory()->create([
-        'estimate_date' => '1988-07-18',
-        'expiry_date' => '1988-08-18',
-    ]);
+    
+    $estimate = Estimate::factory()
+        ->create([
+            'estimate_date' => now(),
+            'expiry_date' => now()->addMonth(),
+        ]);
 
-    $response = postJson("api/v1/estimates/{$estimate->id}/convert-to-invoice")
-        ->assertStatus(200);
+    $response = postJson("api/v1/estimates/{$estimate->id}/convert-to-invoice");
+
+    if ($response->status() !== 200) {
+        $this->fail('Response status is not 200. Response body: ' . json_encode($response->json()));
+    }
+
+    $response->assertStatus(200);
 });
 
 test('delete multiple estimates using a form request', function () {

--- a/tests/Feature/Admin/EstimateTest.php
+++ b/tests/Feature/Admin/EstimateTest.php
@@ -231,7 +231,7 @@ test('estimate mark as rejected', function () {
 });
 
 test('create invoice from estimate', function () {
-    
+
     $estimate = Estimate::factory()
         ->create([
             'estimate_date' => now(),
@@ -241,7 +241,7 @@ test('create invoice from estimate', function () {
     $response = postJson("api/v1/estimates/{$estimate->id}/convert-to-invoice");
 
     if ($response->status() !== 200) {
-        $this->fail('Response status is not 200. Response body: ' . json_encode($response->json()));
+        $this->fail('Response status is not 200. Response body: '.json_encode($response->json()));
     }
 
     $response->assertStatus(200);


### PR DESCRIPTION
#53 

This PR introduces the ability to set negative values for invoice item quantities.

## Use Cases:

### Creating Cancellation Invoices:

1. Duplicate an existing invoice.
2. Change all item quantities to negative values.
3. Save (and send the invoice if necessary).

This simplifies handling refunds or returns while keeping accurate records of canceled items.

### Displaying Free Items Without a Discount:
- Set the quantity of an item to 0 if you want to show that it is provided for free without applying a discount.

This is useful for transparency when including a complimentary item or service in the invoice, while still reflecting its original value.

> Note: Negative quantities are not available on recurring invoices.

## Todo

- [x] Write tests
- [ ] Handle payments for negative total invoices