### PR TITLE
fix: Update .htaccess

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,4 +1,7 @@
 <IfModule mod_rewrite.c>
+
+    RewriteBase /
+
     <IfModule mod_negotiation.c>
         Options -MultiViews -Indexes
     </IfModule>
@@ -18,4 +21,5 @@
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
+    
 </IfModule>


### PR DESCRIPTION
I recently installed InvoiceShelf 2.0.0 version to my Ionos Webhosting and could not access the installation wizard.

I cannot recall the exact server error, but I received something like `500 internal server error...`.

I did minor corrections to the `.htaccess` file which then solved the issue and I could access the installation wizard and complete the installation.