### PR TITLE
Checking version number on version.md file

### DIFF
--- a/app/Console/Commands/UpdateCommand.php
+++ b/app/Console/Commands/UpdateCommand.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands;
 
-use App\Models\Setting;
 use App\Space\Updater;
 use Illuminate\Console\Command;
 
@@ -98,7 +97,7 @@ class UpdateCommand extends Command
 
     public function getInstalledVersion()
     {
-        return Setting::getSetting('version');
+        return preg_replace('~[\r\n]+~', '', File::get(base_path('version.md')));
     }
 
     public function getLatestVersionResponse()

--- a/app/Http/Controllers/AppVersionController.php
+++ b/app/Http/Controllers/AppVersionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Setting;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\File;
 
 class AppVersionController extends Controller
 {
@@ -14,7 +15,7 @@ class AppVersionController extends Controller
      */
     public function __invoke(Request $request)
     {
-        $version = Setting::getSetting('version');
+        $version = preg_replace('~[\r\n]+~', '', File::get(base_path('version.md')));
 
         $channel = Setting::getSetting('updater_channel');
         if (is_null($channel)) {

--- a/app/Http/Controllers/V1/Admin/Update/CheckVersionController.php
+++ b/app/Http/Controllers/V1/Admin/Update/CheckVersionController.php
@@ -3,9 +3,9 @@
 namespace App\Http\Controllers\V1\Admin\Update;
 
 use App\Http\Controllers\Controller;
-use App\Models\Setting;
 use App\Space\Updater;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\File;
 
 class CheckVersionController extends Controller
 {
@@ -26,7 +26,8 @@ class CheckVersionController extends Controller
         set_time_limit(600); // 10 minutes
 
         $channel = $request->get('channel', 'stable');
-        $response = Updater::checkForUpdate(Setting::getSetting('version'), $channel);
+        $version = preg_replace('~[\r\n]+~', '', File::get(base_path('version.md')));
+        $response = Updater::checkForUpdate($version, $channel);
 
         return response()->json($response);
     }


### PR DESCRIPTION
For those who don’t use the integrated updater, the version number in the settings.version field is incorrect because it’s only updated when the updater is used. If someone pulls the app directly from the master branch, the version number in the settings is never updated. The proposed fix is to retrieve the version number directly from the version.md file. This approach seems safe, as the version.md file is only modified during a release.