### PR TITLE
Fix: Capitalise 'date' in invoice due date label

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1588,7 +1588,7 @@
   "pdf_invoice_label": "Invoice",
   "pdf_invoice_number": "Invoice Number",
   "pdf_invoice_date": "Invoice Date",
-  "pdf_invoice_due_date": "Due date",
+  "pdf_invoice_due_date": "Due Date",
   "pdf_notes": "Notes",
   "pdf_items_label": "Items",
   "pdf_quantity_label": "Quantity",


### PR DESCRIPTION
Changes "Due date" to "Due Date" in `pdf_invoice_due_date` translation string to maintain consistent capitalisation across labels.