### PR TITLE
306 update GitHub issuepr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -91,6 +91,16 @@ body:
 
         Now lets collect some information about your environment.
 
+  # Use Docker?.
+  - type: checkboxes
+    id: confirm-docker-install
+    attributes:
+      label: Docker
+      description: 'Please note that unless the issue is with the app itself, you should file a bug report under [docker](https://github.com/InvoiceShelf/docker) repository.'
+      options:
+        - label: App running in Docker Container.
+        - label: Docker container running behind Reverse proxy.
+
   # App Version
   - type: input
     id: invoiceshelf-version

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,7 @@ body:
       label: Issue filing pre-requisites
       description: 'Prior to filing an issue please confirm that:'
       options:
-        - label: I've checked the documentation.
+        - label: I've checked the [documentation](https://docs.invoiceshelf.com/).
           required: true
         - label: I've looked for similar issues both Open and Closed.
           required: true
@@ -52,13 +52,20 @@ body:
       description: A clear step-by-step explanation of how to reproduce your issue
       placeholder: >-
         ## Produces an error:
+
         1. Do X;
+
         2. Do Y;
+
         3. Do Z;
 
+
         ## Works fine:
+
         4. Do X;
+
         5. Do Z;
+
         6. Do Y.
     validations:
       required: true
@@ -172,10 +179,15 @@ body:
         reverse proxy application.
       placeholder: >-
         2023-04-12 10:15:32 [NGINX] 172.16.0.5 - - [12/Apr/2023:10:15:32 +0000] "GET /index.html HTTP/1.1" 200 1024 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
+
         2023-04-12 10:15:33 [NGINX] 172.16.0.7 - - [12/Apr/2023:10:15:33 +0000] "POST /login HTTP/1.1" 302 - "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8"
+
         2023-04-12 10:15:34 [NGINX] 172.16.0.9 - - [12/Apr/2023:10:15:34 +0000] "GET /about HTTP/1.1" 200 2048 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
+
         2023-04-12 10:15:35 [NGINX] 172.16.0.11 - - [12/Apr/2023:10:15:35 +0000] "PUT /api/v1/users/123 HTTP/1.1" 200 - "https://example.com/profile" "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1"
+
         2023-04-12 10:15:36 [NGINX] 172.16.0.13 - - [12/Apr/2023:10:15:36 +0000] "DELETE /api/v1/products/456 HTTP/1.1" 204 - "-" "Dalvik/2.1.0 (Linux; U; Android 10; Pixel 4 Build/QD1A.190821.014.C2)"
+
         2023-04-12 10:15:37 [NGINX] 172.16.0.15 - - [12/Apr/2023:10:15:37 +0000] "GET /easter-egg HTTP/1.1" 200 42 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.82 Safari/537.3"
       render: irc logs
 
@@ -187,19 +199,33 @@ body:
       description: Please provide logs from either PHP or Laravel or both.
       placeholder: >-
         [2015-02-04 10:00:00] production.INFO: Laravel 5.0 released. The world rejoices.
+
         [2015-12-03 12:00:00] production.INFO: PHP 7.0 introduced scalar type declarations. Minds blown.
+
         [2016-05-15 14:00:00] production.INFO: Composer installed new dependencies. Dependency hell avoided.
+
         [2017-08-20 16:00:00] production.INFO: Artisan command executed: migrate. Smooth sailing.
+
         [2018-01-10 09:00:00] production.INFO: User login successful.
+
         [2018-01-10 09:05:00] production.ERROR: Database connection failed. Did you try turning it off and on again?
+
         [2018-01-10 09:10:00] production.WARNING: Deprecated function used in UserController.php. Time to refactor, again.
+
         [2018-01-10 09:15:00] production.ERROR: Uncaught Exception: Division by zero. Oops, math is hard.
+
         [2018-01-10 09:20:00] production.INFO: User logout successful. See you later, alligator.
+
         [2019-03-25 11:00:00] production.INFO: Cache cleared. Fresh start!
+
         [2019-06-30 13:00:00] production.ERROR: Syntax error. Missing semicolon strikes again.
+
         [2020-09-10 15:00:00] production.INFO: User registered. Welcome aboard!
+
         [2021-11-05 17:00:00] production.WARNING: Low disk space. Time to clean up.
+
         [2022-12-20 19:00:00] production.INFO: Server rebooted. All systems go.
+
         [2024-11-14 18:56:20] production.INFO: Unexpected item in the bagging area. Please wait for assistance.
       render: irc logs
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,9 +1,8 @@
 name: Bug report
 description: Template for bug reports
-labels:
-  - bug
-  - triage
-projects: ["InvoiceShelf/2"]
+labels: ['bug', 'triage']
+type: Bug
+projects: ['InvoiceShelf/2']
 assignees:
   - rihards-simanovics
 
@@ -14,7 +13,7 @@ body:
     id: confirm-read-documentation
     attributes:
       label: Issue filing pre-requisites
-      description: "Prior to filing an issue please confirm that:"
+      description: 'Prior to filing an issue please confirm that:'
       options:
         - label: I've checked the documentation.
           required: true
@@ -133,7 +132,7 @@ body:
     id: web-browser
     attributes:
       label: Web Browser
-      placeholder: "Firefox / Safari / or any other (chromium based browser)"
+      placeholder: 'Firefox / Safari / or any other (chromium based browser)'
 
   # OS Version
   - type: input
@@ -162,6 +161,21 @@ body:
         Please provide logs from your Apache, Nginx, Traefik, or any other
         reverse proxy application.
       placeholder: >-
+        2023-04-12 10:15:32 [NGINX] 172.16.0.5 - - [12/Apr/2023:10:15:32 +0000] "GET /index.html HTTP/1.1" 200 1024 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
+        2023-04-12 10:15:33 [NGINX] 172.16.0.7 - - [12/Apr/2023:10:15:33 +0000] "POST /login HTTP/1.1" 302 - "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8"
+        2023-04-12 10:15:34 [NGINX] 172.16.0.9 - - [12/Apr/2023:10:15:34 +0000] "GET /about HTTP/1.1" 200 2048 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
+        2023-04-12 10:15:35 [NGINX] 172.16.0.11 - - [12/Apr/2023:10:15:35 +0000] "PUT /api/v1/users/123 HTTP/1.1" 200 - "https://example.com/profile" "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1"
+        2023-04-12 10:15:36 [NGINX] 172.16.0.13 - - [12/Apr/2023:10:15:36 +0000] "DELETE /api/v1/products/456 HTTP/1.1" 204 - "-" "Dalvik/2.1.0 (Linux; U; Android 10; Pixel 4 Build/QD1A.190821.014.C2)"
+        2023-04-12 10:15:37 [NGINX] 172.16.0.15 - - [12/Apr/2023:10:15:37 +0000] "GET /easter-egg HTTP/1.1" 200 42 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.82 Safari/537.3"
+      render: irc logs
+
+  # PHP/Laravel Logs
+  - type: textarea
+    id: log-laravel
+    attributes:
+      label: Laravel/PHP logs
+      description: Please provide logs from either PHP or Laravel or both.
+      placeholder: >-
         [2015-02-04 10:00:00] production.INFO: Laravel 5.0 released. The world rejoices.
         [2015-12-03 12:00:00] production.INFO: PHP 7.0 introduced scalar type declarations. Minds blown.
         [2016-05-15 14:00:00] production.INFO: Composer installed new dependencies. Dependency hell avoided.
@@ -177,21 +191,6 @@ body:
         [2021-11-05 17:00:00] production.WARNING: Low disk space. Time to clean up.
         [2022-12-20 19:00:00] production.INFO: Server rebooted. All systems go.
         [2024-11-14 18:56:20] production.INFO: Unexpected item in the bagging area. Please wait for assistance.
-      render: irc logs
-
-  # PHP/Laravel Logs
-  - type: textarea
-    id: log-laravel
-    attributes:
-      label: Laravel/PHP logs
-      description: Please provide logs from either PHP or Laravel or both.
-      placeholder: >-
-        2023-04-12 10:15:32 [NGINX] 172.16.0.5 - - [12/Apr/2023:10:15:32 +0000] "GET /index.html HTTP/1.1" 200 1024 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
-        2023-04-12 10:15:33 [NGINX] 172.16.0.7 - - [12/Apr/2023:10:15:33 +0000] "POST /login HTTP/1.1" 302 - "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8"
-        2023-04-12 10:15:34 [NGINX] 172.16.0.9 - - [12/Apr/2023:10:15:34 +0000] "GET /about HTTP/1.1" 200 2048 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
-        2023-04-12 10:15:35 [NGINX] 172.16.0.11 - - [12/Apr/2023:10:15:35 +0000] "PUT /api/v1/users/123 HTTP/1.1" 200 - "https://example.com/profile" "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1"
-        2023-04-12 10:15:36 [NGINX] 172.16.0.13 - - [12/Apr/2023:10:15:36 +0000] "DELETE /api/v1/products/456 HTTP/1.1" 204 - "-" "Dalvik/2.1.0 (Linux; U; Android 10; Pixel 4 Build/QD1A.190821.014.C2)"
-        2023-04-12 10:15:37 [NGINX] 172.16.0.15 - - [12/Apr/2023:10:15:37 +0000] "GET /easter-egg HTTP/1.1" 200 42 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.82 Safari/537.3"
       render: irc logs
 
   # Special thanks

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
   - type: checkboxes
     id: confirm-read-documentation
     attributes:
-      label: Issue filing pre-requisites
+      label: Issue filing prerequisites
       description: 'Prior to filing an issue please confirm that:'
       options:
         - label: I've checked the [documentation](https://docs.invoiceshelf.com/).
@@ -20,7 +20,7 @@ body:
         - label: I've looked for similar issues both Open and Closed.
           required: true
         - label: >-
-            Ive tried clearing both cache and cookies in my browser or tried
+            I've tried clearing both cache and cookies in my browser or tried
             opening the app in the Incognito/InPrivate window.
           required: true
 
@@ -28,19 +28,19 @@ body:
   - type: markdown
     attributes:
       value: >-
-        If you did all of the above, we first would like to thank you for taking
-        the time to fill out this bug report, it will help us tremendously to
+        If you did all of the above, we would first like to thank you for taking
+        the time to fill out this bug report. It will help us tremendously to
         find and fix the issue sooner!
 
-  # Description fo the bug
+  # Description of the bug
   - type: textarea
     id: bug-description
     attributes:
       label: Describe the bug
       description: A clear and concise description of what the bug is.
       placeholder: >-
-        When doing `x`, `y`, and `z` in that order, an error occurs, but when x,
-        z and then y is done, the error does not occur.
+        When doing `x`, `y`, and `z` in that order, an error occurs, but when `x`,
+        `z` and then `y` is done, the error does not occur.
     validations:
       required: true
 
@@ -72,21 +72,21 @@ body:
 
   # Expected Behaviour
   - type: textarea
-    id: expected-behavior
+    id: expected-behaviour
     attributes:
-      label: Expected behavior
+      label: Expected behaviour
       description: A clear and concise description of what you expected to happen.
-      placeholder: doing  `x`, `y`, and `z` in that order should not generate an error.
+      placeholder: Doing `x`, `y`, and `z` in that order should not generate an error.
     validations:
       required: true
 
   # Actual Behaviour
   - type: textarea
-    id: actual-behavior
+    id: actual-behaviour
     attributes:
-      label: Actual behavior
-      description: A clear and concise description of what actually happen.
-      placeholder: doing  `x`, `y`, and `z` in that order generate an error.
+      label: Actual behaviour
+      description: A clear and concise description of what actually happens.
+      placeholder: Doing `x`, `y`, and `z` in that order generates an error.
     validations:
       required: true
 
@@ -94,16 +94,16 @@ body:
   - type: markdown
     attributes:
       value: |-
-        ## Envirment
+        ## Environment
 
-        Now lets collect some information about your environment.
+        Now let's collect some information about your environment.
 
-  # Use Docker?.
+  # Use Docker?
   - type: checkboxes
     id: confirm-docker-install
     attributes:
       label: Docker
-      description: 'Please note that unless the issue is with the app itself, you should file a bug report under [docker](https://github.com/InvoiceShelf/docker) repository.'
+      description: 'Please note that unless the issue is with the app itself, you should file a bug report under the [docker](https://github.com/InvoiceShelf/docker) repository.'
       options:
         - label: App running in Docker Container.
         - label: Docker container running behind Reverse proxy.
@@ -131,7 +131,7 @@ body:
     id: database-type
     attributes:
       label: Database type
-      placeholder: MariaDB / MySQL / PostreSQL / SQLite
+      placeholder: MariaDB / MySQL / PostgreSQL / SQLite
     validations:
       required: true
 
@@ -149,14 +149,14 @@ body:
     id: web-browser
     attributes:
       label: Web Browser
-      placeholder: 'Firefox / Safari / or any other (chromium based browser)'
+      placeholder: 'Firefox / Safari / or any other (Chromium-based browser)'
 
   # OS Version
   - type: input
     id: server-os
     attributes:
       label: Server OS
-      description: If Linux please make sure to provide both distro name and it's version
+      description: If Linux, please make sure to provide both the distro name and its version
       placeholder: Windows / Linux (e.g. Ubuntu 24.04)
 
   # Associated Logs
@@ -166,7 +166,7 @@ body:
         ## Logs
 
 
-        last but not least, could you please take some time to get us the logs
+        Last but not least, could you please take some time to get us the logs
         for:
 
   # Log Reverse proxy
@@ -212,7 +212,7 @@ body:
 
         [2018-01-10 09:10:00] production.WARNING: Deprecated function used in UserController.php. Time to refactor, again.
 
-        [2018-01-10 09:15:00] production.ERROR: Uncaught Exception: Division by zero. Oops, math is hard.
+        [2018-01-10 09:15:00] production.ERROR: Uncaught Exception: Division by zero. Oops, maths is hard.
 
         [2018-01-10 09:20:00] production.INFO: User logout successful. See you later, alligator.
 

--- a/.github/ISSUE_TEMPLATE/code_quality_issue.yml
+++ b/.github/ISSUE_TEMPLATE/code_quality_issue.yml
@@ -5,7 +5,7 @@ description: Create a code quality issue to help InvoiceShelf keep a clean codeb
 labels:
   - code quality
   - triage
-projects: ["InvoiceShelf/2"]
+projects: ['InvoiceShelf/2']
 assignees:
   - rihards-simanovics
 
@@ -19,6 +19,23 @@ body:
         > Have you checked for similar code quality issues? There's a
         possibility your suggestion is already being tracked. Please do a
         thorough search before creating a new issue.
+
+  # Ask user to confirm they've tried to fix or research the issue before
+  # posting a bug report.
+  - type: checkboxes
+    id: confirm-read-documentation
+    attributes:
+      label: Issue filing pre-requisites
+      description: 'Prior to filing an issue please confirm that:'
+      options:
+        - label: I've checked the documentation.
+          required: true
+        - label: I've looked for similar issues both Open and Closed.
+          required: true
+        - label: >-
+            Ive tried clearing both cache and cookies in my browser or tried
+            opening the app in the Incognito/InPrivate window.
+          required: true
 
   # Issue body
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/code_quality_issue.yml
+++ b/.github/ISSUE_TEMPLATE/code_quality_issue.yml
@@ -28,7 +28,7 @@ body:
       label: Issue filing pre-requisites
       description: 'Prior to filing an issue please confirm that:'
       options:
-        - label: I've checked the documentation.
+        - label: I've checked the [documentation](https://docs.invoiceshelf.com/).
           required: true
         - label: I've looked for similar issues both Open and Closed.
           required: true
@@ -62,9 +62,11 @@ body:
     attributes:
       label: Gains
       description: What would fixing this code quality issue bring to the source code?
-      value: |
+      placeholder: >-
         - eg. A better readability.
+
         - eg. Uncoupling concepts X and Y.
+
         - eg. Clarifying the responsibility of class C.
     validations:
       required: true
@@ -75,9 +77,11 @@ body:
     attributes:
       label: Requirements
       description: Describe all the requirements to solve the code quality issue.
-      value: |
+      placeholder: >-
         - eg. Using a specific design pattern.
+
         - eg. Separating Interface I into three new interfaces I1, I2 and I3.
+
         - eg. Regrouping the duplicated process into a new helper.
 
   # Remarks

--- a/.github/ISSUE_TEMPLATE/code_quality_issue.yml
+++ b/.github/ISSUE_TEMPLATE/code_quality_issue.yml
@@ -25,7 +25,7 @@ body:
   - type: checkboxes
     id: confirm-read-documentation
     attributes:
-      label: Issue filing pre-requisites
+      label: Issue filing prerequisites
       description: 'Prior to filing an issue please confirm that:'
       options:
         - label: I've checked the [documentation](https://docs.invoiceshelf.com/).
@@ -33,7 +33,7 @@ body:
         - label: I've looked for similar issues both Open and Closed.
           required: true
         - label: >-
-            Ive tried clearing both cache and cookies in my browser or tried
+            I've tried clearing both cache and cookies in my browser or tried
             opening the app in the Incognito/InPrivate window.
           required: true
 
@@ -63,11 +63,11 @@ body:
       label: Gains
       description: What would fixing this code quality issue bring to the source code?
       placeholder: >-
-        - eg. A better readability.
+        - e.g. Better readability.
 
-        - eg. Uncoupling concepts X and Y.
+        - e.g. Uncoupling concepts X and Y.
 
-        - eg. Clarifying the responsibility of class C.
+        - e.g. Clarifying the responsibility of class C.
     validations:
       required: true
 
@@ -78,11 +78,11 @@ body:
       label: Requirements
       description: Describe all the requirements to solve the code quality issue.
       placeholder: >-
-        - eg. Using a specific design pattern.
+        - e.g. Using a specific design pattern.
 
-        - eg. Separating Interface I into three new interfaces I1, I2 and I3.
+        - e.g. Separating Interface I into three new interfaces I1, I2 and I3.
 
-        - eg. Regrouping the duplicated process into a new helper.
+        - e.g. Regrouping the duplicated process into a new helper.
 
   # Remarks
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,6 @@ contact_links:
   - name: Translation issue
     url: https://crowdin.com/project/invoiceshelf
     about: Help improve translations on Crowdin.
-  - name: Question & Discussion
+  - name: Support, Question & Discussion - Official Discord Server
     url: https://discord.gg/hwg2FtwWHW
     about: Post your questions and join the discussion. You can participate in chats on every channel.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -27,15 +27,15 @@ body:
   - type: checkboxes
     id: confirm-read-documentation
     attributes:
-      label: Issue filing pre-requisites
+      label: Issue filing prerequisites
       description: 'Prior to filing an issue please confirm that:'
       options:
         - label: I've checked the [documentation](https://docs.invoiceshelf.com/).
           required: true
-        - label: I've looked for similar issues with feature request both Open and Closed.
+        - label: I've looked for similar issues with feature requests both Open and Closed.
           required: true
         - label: >-
-            Ive tried clearing both cache and cookies in my browser or tried
+            I've tried clearing both cache and cookies in my browser or tried
             opening the app in the Incognito/InPrivate window.
           required: true
 
@@ -46,7 +46,7 @@ body:
       label: What feature or improvement do you think would benefit InvoiceShelf?
       description: Please include your use case
       placeholder: >-
-        I propose that feature J be implement as i believe it will greatly benefit the application.
+        I propose that feature J be implemented as I believe it will greatly benefit the application.
     validations:
       required: true
 
@@ -57,7 +57,7 @@ body:
         ---
 
 
-        Please include a list changes required to make this improvement. A good
+        Please include a list of changes required to make this improvement. A good
         rule of thumb is to start your proposal with no more than 7 high-level
         requirements.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,7 +4,8 @@ name: Feature Request
 labels:
   - feature request
   - triage
-projects: ["InvoiceShelf/2"]
+type: Feature
+projects: ['InvoiceShelf/2']
 assignees:
   - rihards-simanovics
 description: >-
@@ -20,6 +21,23 @@ body:
         >Have you checked for similar feature requests? There's a possibility
         your suggestion is already being tracked. Please do a thorough search
         before creating a new issue.
+
+  # Ask user to confirm they've tried to fix or research the issue before
+  # posting a bug report.
+  - type: checkboxes
+    id: confirm-read-documentation
+    attributes:
+      label: Issue filing pre-requisites
+      description: 'Prior to filing an issue please confirm that:'
+      options:
+        - label: I've checked the documentation.
+          required: true
+        - label: I've looked for similar issues with feature request both Open and Closed.
+          required: true
+        - label: >-
+            Ive tried clearing both cache and cookies in my browser or tried
+            opening the app in the Incognito/InPrivate window.
+          required: true
 
   # Description
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -30,7 +30,7 @@ body:
       label: Issue filing pre-requisites
       description: 'Prior to filing an issue please confirm that:'
       options:
-        - label: I've checked the documentation.
+        - label: I've checked the [documentation](https://docs.invoiceshelf.com/).
           required: true
         - label: I've looked for similar issues with feature request both Open and Closed.
           required: true
@@ -45,6 +45,8 @@ body:
     attributes:
       label: What feature or improvement do you think would benefit InvoiceShelf?
       description: Please include your use case
+      placeholder: >-
+        I propose that feature J be implement as i believe it will greatly benefit the application.
     validations:
       required: true
 
@@ -65,9 +67,11 @@ body:
     attributes:
       label: Requirements
       description: Describe all the requirements to make your idea happen.
-      value: |
+      placeholder: >-
         - This proposal will accomplish X
+
         - This proposal will accomplish Y
+
         - This proposal will accomplish Z
     validations:
       required: true
@@ -77,7 +81,7 @@ body:
     id: invoiceshelf_version
     attributes:
       label: App Version
-      description: Which version of InvoiceShelf are you using?
+      description: Which version of InvoiceShelf are you currently using?
       placeholder: v0.0.0
     validations:
       required: true

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,4 +1,4 @@
-## pre-review checklist
+## Pre-review request checklist
 
 - [ ] (\*) I have listed all changes in the `Changes` section.
 - [ ] (opt) I have listed all issues this PR addresses in the `Issues` section [with the issue/discussion ID's](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -4,7 +4,6 @@
 - [ ] (opt) I have listed all issues this PR addresses in the `Issues` section [with the issue/discussion ID's](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).
 - [ ] (\*) I have tested my changes.
 - [ ] (\*) I have considered backwards compatibility.
-- [ ] (\*) I have removed this checklist and any unused sections.
 
 ## Changes
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,18 @@
+## pre-review checklist
+
+- [ ] (\*) I have listed all changes in the `Changes` section.
+- [ ] (opt) I have listed all issues this PR addresses in the `Issues` section [with the issue/discussion ID's](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).
+- [ ] (\*) I have tested my changes.
+- [ ] (\*) I have considered backwards compatibility.
+- [ ] (\*) I have removed this checklist and any unused sections.
+
+## Changes
+
+- Added feature X
+- Removed Code Y
+- Refactored code Z
+
+## Issues
+
+- fixes #
+- closes #

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,7 +1,7 @@
 ## Pre-review request checklist
 
 - [ ] (\*) I have listed all changes in the `Changes` section.
-- [ ] (opt) I have listed all issues this PR addresses in the `Issues` section [with the issue/discussion ID's](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).
+- [ ] (opt) I have listed all issues this PR addresses in the `Issues` section [with the issue/discussion IDs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).
 - [ ] (\*) I have tested my changes.
 - [ ] (\*) I have considered backwards compatibility.
 


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section [with the issue/discussion ID's](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

- Added default selection of issue type for Bug Report and Feature Request templates
- Moved Bug Report placeholder logs around, as Laravel logs were under Nginx and vice versa.
- Added "Captcha" checkboxes to the Feature Requests template, as users sometimes fail to check for existing Feature Requests.
- Code Quality is the same as the above point, but it is also more important for consistency across templates, as both BR and FR templates now have "Captchas".
- Updated config to explicitly state that "Support, Question & Discussion" happens on the Official Discord Server.
- Added new PR template; only md is supported however, using URL query, different types can be selected [based on GitHub docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository).
- Added Docker question in Bug Report template.
- Added formatting corrections to placeholder and links to some labels like docs
- Plus, various other typos, spelling, and grammar fixes.

## Issues

- closes #306 