### PR TITLE
Fix: AWS SES Mailer

### DIFF
--- a/app/Http/Controllers/V1/Admin/Settings/MailConfigurationController.php
+++ b/app/Http/Controllers/V1/Admin/Settings/MailConfigurationController.php
@@ -58,6 +58,7 @@ class MailConfigurationController extends Controller
             'mail_mailgun_secret' => config('services.mailgun.secret'),
             'mail_ses_key' => config('services.ses.key'),
             'mail_ses_secret' => config('services.ses.secret'),
+            'mail_ses_region' => config('services.ses.region'),
         ];
 
         return response()->json($MailData);

--- a/app/Space/EnvironmentManager.php
+++ b/app/Space/EnvironmentManager.php
@@ -296,6 +296,7 @@ class EnvironmentManager
                     'MAIL_FROM_NAME' => $request->get('from_name'),
                     'SES_KEY' => $request->get('mail_ses_key'),
                     'SES_SECRET' => $request->get('mail_ses_secret'),
+                    'SES_REGION' => $request->get('mail_ses_region'),
                 ];
 
                 break;

--- a/config/services.php
+++ b/config/services.php
@@ -48,4 +48,10 @@ return [
         'auth_token' => env('CRON_JOB_AUTH_TOKEN', 0),
     ],
 
+    'ses' => [
+        'key' => env('SES_KEY'),
+        'secret' => env('SES_SECRET'),
+        'region' => env('SES_REGION', 'us-east-1'),
+    ],
+
 ];

--- a/lang/en.json
+++ b/lang/en.json
@@ -893,6 +893,7 @@
       "mailgun_endpoint": "Mailgun Endpoint",
       "ses_secret": "SES Secret",
       "ses_key": "SES Key",
+      "ses_region": "AWS Region",
       "password": "Mail Password",
       "username": "Mail Username",
       "mail_config": "Mail Configuration",
@@ -1281,7 +1282,7 @@
       "title": "Update App",
       "description": "You can easily update InvoiceShelf by checking for a new update by clicking the button below",
       "check_update": "Check for updates",
-      "insider_consent" : "Opt-in for Insider releases. Recommended for testing purposes only.",
+      "insider_consent": "Opt-in for Insider releases. Recommended for testing purposes only.",
       "avail_update": "New Update available",
       "next_version": "Next version",
       "requirements": "Requirements",
@@ -1469,9 +1470,9 @@
       "failed": "Domain verification failed. Please enter valid domain name.",
       "verify_and_continue": "Verify And Continue",
       "notes": {
-        "notes" : "Notes:",
-        "not_contain" : "App domain should not contain",
-        "or" : "or",
+        "notes": "Notes:",
+        "not_contain": "App domain should not contain",
+        "or": "or",
         "in_front": "in front of the domain.",
         "if_you": "If you're accessing the website on a different port, please mention the port. For example:"
       }

--- a/lang/es.json
+++ b/lang/es.json
@@ -893,6 +893,7 @@
       "mailgun_endpoint": "Mailgun endpoint",
       "ses_secret": "Secreto SES",
       "ses_key": "Clave SES",
+      "ses_region": "Región de AWS",
       "password": "Contraseña de correo",
       "username": "Nombre de usuario de correo",
       "mail_config": "Configuración de correo",

--- a/lang/pt-br.json
+++ b/lang/pt-br.json
@@ -571,6 +571,7 @@
       "mailgun_endpoint": "Mailgun Endpoint",
       "ses_secret": "SES Segredo",
       "ses_key": "SES Chave",
+      "ses_region": "Região AWS",
       "password": "Senha do Email",
       "username": "Nome de Usuário do Email",
       "mail_config": "Configuração de Email",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1484,6 +1484,7 @@
       "mailgun_endpoint": "Endpoint do Mailgun",
       "ses_secret": "Senha do SES",
       "ses_key": "Chave SES",
+      "ses_region": "Região AWS",
       "password": "Senha do email",
       "username": "Nome do Usuário do email",
       "mail_config": "Configuração de email",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -893,6 +893,7 @@
       "mailgun_endpoint": "Mailgun Endpoint",
       "ses_secret": "SES Secret",
       "ses_key": "SES Key",
+      "ses_region": "AWS Region",
       "password": "Mail Password",
       "username": "Mail Username",
       "mail_config": "Mail Configuration",

--- a/resources/scripts/admin/stores/mail-driver.js
+++ b/resources/scripts/admin/stores/mail-driver.js
@@ -37,6 +37,7 @@ export const useMailDriverStore = (useWindow = false) => {
         mail_port: null,
         mail_ses_key: '',
         mail_ses_secret: '',
+        mail_ses_region: '',
         mail_encryption: 'tls',
         from_mail: '',
         from_name: '',

--- a/resources/scripts/admin/views/installation/mail-driver/SesMailDriver.vue
+++ b/resources/scripts/admin/views/installation/mail-driver/SesMailDriver.vue
@@ -167,6 +167,25 @@
           </template>
         </BaseInput>
       </BaseInputGroup>
+
+      <BaseInputGroup
+        :label="$t('settings.mail.ses_region')"
+        :content-loading="isFetchingInitialData"
+        :error="
+          v$.sesConfig.mail_ses_region.$error &&
+          v$.sesConfig.mail_ses_region.$errors[0].$message
+        "
+        required
+      >
+        <BaseInput
+          v-model.trim="mailDriverStore.sesConfig.mail_ses_region"
+          :content-loading="isFetchingInitialData"
+          type="text"
+          name="mail_ses_region"
+          :invalid="v$.sesConfig.mail_ses_region.$error"
+          @input="v$.sesConfig.mail_ses_region.$touch()"
+        />
+      </BaseInputGroup>
     </div>
 
     <BaseButton
@@ -235,6 +254,9 @@ const rules = computed(() => {
         required: helpers.withMessage(t('validation.required'), required),
       },
       mail_ses_secret: {
+        required: helpers.withMessage(t('validation.required'), required),
+      },
+      mail_ses_region: {
         required: helpers.withMessage(t('validation.required'), required),
       },
       mail_encryption: {

--- a/resources/scripts/admin/views/settings/mail-driver/SesMailDriver.vue
+++ b/resources/scripts/admin/views/settings/mail-driver/SesMailDriver.vue
@@ -161,6 +161,26 @@
           </template>
         </BaseInput>
       </BaseInputGroup>
+
+      <BaseInputGroup
+        :label="$t('settings.mail.ses_region')"
+        :content-loading="isFetchingInitialData"
+        :error="
+          v$.sesConfig.mail_ses_region.$error &&
+          v$.sesConfig.mail_ses_region.$errors[0].$message
+        "
+        required
+      >
+        <BaseInput
+          v-model.trim="mailDriverStore.sesConfig.mail_ses_region"
+          :content-loading="isFetchingInitialData"
+          type="text"
+          name="mail_ses_region"
+          :invalid="v$.sesConfig.mail_ses_region.$error"
+          @input="v$.sesConfig.mail_ses_region.$touch()"
+        />
+      </BaseInputGroup>
+
     </BaseInputGrid>
 
     <div class="flex my-10">
@@ -236,6 +256,9 @@ const rules = computed(() => {
         required: helpers.withMessage(t('validation.required'), required),
       },
       mail_ses_secret: {
+        required: helpers.withMessage(t('validation.required'), required),
+      },
+      mail_ses_region: {
         required: helpers.withMessage(t('validation.required'), required),
       },
       mail_encryption: {


### PR DESCRIPTION
As reported on issue #357, the aws ses configuration was not able to store because of the missing `ses` service config. Additionally was added a `AWS Region` field to be used by the `ses`.

closes #357