### PR TITLE
fix: Backup Job

### DIFF
--- a/app/Jobs/CreateBackupJob.php
+++ b/app/Jobs/CreateBackupJob.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Spatie\Backup\Config\Config;
 use Spatie\Backup\Tasks\Backup\BackupJobFactory;
 
 class CreateBackupJob implements ShouldQueue
@@ -41,7 +42,8 @@ class CreateBackupJob implements ShouldQueue
 
         config(['backup.backup.destination.disks' => [$prefix.$fileDisk->driver]]);
 
-        $backupJob = BackupJobFactory::createFromArray(config('backup'));
+        $config = Config::fromArray(config('backup'));
+        $backupJob = BackupJobFactory::createFromConfig($config);
         if (! defined('SIGINT')) {
             $backupJob->disableSignals();
         }


### PR DESCRIPTION
Since `laravel-backup` major version was updated from `8` to `9`, the backup ability was compromised, the main reason is the change on the method contract from `BackupFactory` that now the `createFromArray` no longer exists.