### PR TITLE
fix: Payment confirmation error

### DIFF
--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -459,7 +459,7 @@ class Payment extends Model implements HasMedia
             ->setNextNumbers();
 
         $data['payment_number'] = $serial->getNextNumber();
-        $data['payment_date'] = Carbon::now()->format('y-m-d');
+        $data['payment_date'] = Carbon::now();
         $data['amount'] = $invoice->total;
         $data['invoice_id'] = $invoice->id;
         $data['payment_method_id'] = request()->payment_method_id;


### PR DESCRIPTION
Error caused when using Payments module, when try Stripe redirects back to InvoiceShelf, and the module calls the InvoiceShelf `generatePayment`.

Relates #369 and https://github.com/InvoiceShelf/module-payments/issues/10