### PR TITLE
fix: Create item with tax

### DIFF
--- a/resources/scripts/admin/views/items/Create.vue
+++ b/resources/scripts/admin/views/items/Create.vue
@@ -184,7 +184,7 @@ const taxes = computed({
         return {
           ...tax,
           tax_type_id: tax.id,
-          tax_name: `${tax.name} (${tax.calculation_type === 'fixed' 
+          tax_name: `${tax.name} (${tax.calculation_type === 'fixed'
             ? new Intl.NumberFormat(undefined, {
                 style: 'currency',
                 currency: companyStore.selectedCompanyCurrency.code
@@ -209,7 +209,7 @@ const getTaxTypes = computed(() => {
     return {
       ...tax,
       tax_type_id: tax.id,
-      tax_name: `${tax.name} (${tax.calculation_type === 'fixed' 
+      tax_name: `${tax.name} (${tax.calculation_type === 'fixed'
         ? new Intl.NumberFormat(undefined, {
             style: 'currency',
             currency: companyStore.selectedCompanyCurrency.code
@@ -292,7 +292,7 @@ async function submitItem() {
           tax_type_id: tax.tax_type_id,
           calculation_type: tax.calculation_type,
           fixed_amount: tax.fixed_amount,
-          amount: tax.calculation_type === 'fixed' ? tax.fixed_amount : price.value * tax.percent,
+          amount: tax.calculation_type === 'fixed' ? tax.fixed_amount : Math.round(price.value * tax.percent),
           percent: tax.percent,
           name: tax.name,
           collective_tax: 0,


### PR DESCRIPTION
When the `tax-per-item` is enabled and also has a tax added, during the item creation, the price + tax returns an amount as float making the database fail. To fix this was necessary to round the result.

I tried to create an item with price € 24,40 + 21% of tax, the result will be `512.4`, causing the issue:

![bug-fix-tax-per-item](https://github.com/user-attachments/assets/91354a0f-a854-403c-860e-d11ab251e2b1)
