### PR TITLE
fix: Create item with tax (ItemModal)

### DIFF
--- a/resources/scripts/admin/components/modal-components/ItemModal.vue
+++ b/resources/scripts/admin/components/modal-components/ItemModal.vue
@@ -208,15 +208,15 @@ const v$ = useVuelidate(
 
 const getTaxTypes = computed(() => {
   return taxTypeStore.taxTypes.map((tax) => {
-    const amount = tax.calculation_type === 'fixed' 
+    const amount = tax.calculation_type === 'fixed'
       ? new Intl.NumberFormat(undefined, {
           style: 'currency',
           currency: companyStore.selectedCompanyCurrency.code
         }).format(tax.fixed_amount / 100)
       : `${tax.percent}%`
-    
-    return { 
-      ...tax, 
+
+    return {
+      ...tax,
       tax_name: `${tax.name} (${amount})`
     }
   })
@@ -239,7 +239,7 @@ async function submitItemData() {
     taxes: itemStore.currentItem.taxes.map((tax) => {
       return {
         tax_type_id: tax.id,
-        amount: tax.calculation_type === 'fixed' ? tax.fixed_amount : (price.value * tax.percent) / 100,
+        amount: tax.calculation_type === 'fixed' ? tax.fixed_amount : Math.round(price.value * tax.percent),
         percent: tax.percent,
         fixed_amount: tax.fixed_amount,
         calculation_type: tax.calculation_type,


### PR DESCRIPTION
The issue was found during an Item creation inside the Invoice, Estimates or Recurring Invoice, the same fix that was applied into the Item creation view, now is needed into ItemModal. The root cause is that price + tax returns an amount as float making the database fail.

![create_product_invoice](https://github.com/user-attachments/assets/99da7fcf-49c4-443d-8222-b9e38e807d90)


Relates #377