### PR TITLE
Add BCC email configuration for invoice emails

### DIFF
--- a/app/Mail/SendInvoiceMail.php
+++ b/app/Mail/SendInvoiceMail.php
@@ -4,6 +4,7 @@ namespace App\Mail;
 
 use App\Models\EmailLog;
 use App\Models\Invoice;
+use App\Models\CompanySetting;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
@@ -50,6 +51,12 @@ class SendInvoiceMail extends Mailable
         $mailContent = $this->from($this->data['from'], config('mail.from.name'))
             ->subject($this->data['subject'])
             ->markdown('emails.send.invoice', ['data', $this->data]);
+
+        // Add BCC if configured
+        $bccEmail = CompanySetting::getSetting('invoice_email_bcc', $this->data['invoice']['company_id']);
+        if (!empty($bccEmail)) {
+            $mailContent->bcc($bccEmail);
+        }
 
         if ($this->data['attach']['data']) {
             $mailContent->attachData(

--- a/app/Mail/SendInvoiceMail.php
+++ b/app/Mail/SendInvoiceMail.php
@@ -2,9 +2,9 @@
 
 namespace App\Mail;
 
+use App\Models\CompanySetting;
 use App\Models\EmailLog;
 use App\Models\Invoice;
-use App\Models\CompanySetting;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
@@ -52,9 +52,8 @@ class SendInvoiceMail extends Mailable
             ->subject($this->data['subject'])
             ->markdown('emails.send.invoice', ['data', $this->data]);
 
-        // Add BCC if configured
         $bccEmail = CompanySetting::getSetting('invoice_email_bcc', $this->data['invoice']['company_id']);
-        if (!empty($bccEmail)) {
+        if (! empty($bccEmail)) {
             $mailContent->bcc($bccEmail);
         }
 

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -254,6 +254,7 @@ class Company extends Model implements HasMedia
             'estimate_convert_action' => 'no_action',
             'automatically_expire_public_links' => 'YES',
             'link_expiry_days' => 7,
+            'invoice_email_bcc' => '',
         ];
 
         CompanySetting::setSettings($settings, $this->id);

--- a/database/migrations/2025_06_13_132430_add_invoice_email_bcc_to_company_settings.php
+++ b/database/migrations/2025_06_13_132430_add_invoice_email_bcc_to_company_settings.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\CompanySetting;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $companies = \App\Models\Company::all();
+
+        foreach ($companies as $company) {
+            CompanySetting::setSettings([
+                'invoice_email_bcc' => '',
+            ], $company->id);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $companies = \App\Models\Company::all();
+
+        foreach ($companies as $company) {
+            CompanySetting::where('company_id', $company->id)
+                ->where('key', 'invoice_email_bcc')
+                ->delete();
+        }
+    }
+};

--- a/database/migrations/2025_06_13_132430_add_invoice_email_bcc_to_company_settings.php
+++ b/database/migrations/2025_06_13_132430_add_invoice_email_bcc_to_company_settings.php
@@ -1,9 +1,8 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
+use App\Models\Company;
 use App\Models\CompanySetting;
+use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration
 {
@@ -12,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        $companies = \App\Models\Company::all();
+        $companies = Company::all();
 
         foreach ($companies as $company) {
             CompanySetting::setSettings([
@@ -26,7 +25,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        $companies = \App\Models\Company::all();
+        $companies = Company::all();
 
         foreach ($companies as $company) {
             CompanySetting::where('company_id', $company->id)

--- a/lang/de.json
+++ b/lang/de.json
@@ -1039,7 +1039,11 @@
         "disable_on_invoice_partial_paid": "Deaktivieren, nachdem Teilzahlung erfasst wurde",
         "disable_on_invoice_paid": "Deaktivieren, nachdem vollständige Zahlung erfasst wurde",
         "disable_on_invoice_sent": "Deaktivieren, nachdem Rechnung gesendet wurde",
-        "retrospective_edits_description": " Basierend auf den Gesetzen Ihres Landes oder Ihrer Präferenz, können Sie Benutzer daran hindern, fertige Rechnungen zu bearbeiten."
+        "retrospective_edits_description": " Basierend auf den Gesetzen Ihres Landes oder Ihrer Präferenz, können Sie Benutzer daran hindern, fertige Rechnungen zu bearbeiten.",
+        "invoice_email_bcc": "BCC E-Mail-Adresse",
+        "invoice_email_bcc_placeholder": "BCC E-Mail-Adresse eingeben",
+        "bcc_settings": "BCC Einstellungen",
+        "bcc_settings_description": "Konfigurieren Sie BCC-Empfänger für Rechnungs-E-Mails"
       },
       "estimates": {
         "title": "Angebote",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1042,7 +1042,11 @@
         "disable_on_invoice_partial_paid": "Disable after partial payment is recorded",
         "disable_on_invoice_paid": "Disable after full payment is recorded",
         "disable_on_invoice_sent": "Disable after invoice is sent",
-        "retrospective_edits_description": " Based on your country's laws or your preference, you can restrict users from editing finalised invoices."
+        "retrospective_edits_description": " Based on your country's laws or your preference, you can restrict users from editing finalised invoices.",
+        "invoice_email_bcc": "BCC Email Address",
+        "invoice_email_bcc_placeholder": "Enter BCC email address",
+        "bcc_settings": "BCC Settings",
+        "bcc_settings_description": "Configure BCC recipients for invoice emails"
       },
       "estimates": {
         "title": "Estimates",

--- a/resources/scripts/admin/views/settings/customization/invoices/InvoicesTab.vue
+++ b/resources/scripts/admin/views/settings/customization/invoices/InvoicesTab.vue
@@ -13,6 +13,10 @@
 
   <InvoicesTabDefaultFormats />
 
+  <BaseDivider class="my-8" />
+
+  <InvoicesTabBcc />
+
   <BaseDivider class="mt-6 mb-2" />
 
   <ul class="divide-y divide-gray-200">
@@ -35,6 +39,7 @@ import InvoicesTabInvoiceNumber from './InvoicesTabInvoiceNumber.vue'
 import InvoicesTabRetrospective from './InvoicesTabRetrospective.vue'
 import InvoicesTabDueDate from './InvoicesTabDueDate.vue'
 import InvoicesTabDefaultFormats from './InvoicesTabDefaultFormats.vue'
+import InvoicesTabBcc from './InvoicesTabBcc.vue'
 
 const utils = inject('utils')
 const companyStore = useCompanyStore()

--- a/resources/scripts/admin/views/settings/customization/invoices/InvoicesTabBcc.vue
+++ b/resources/scripts/admin/views/settings/customization/invoices/InvoicesTabBcc.vue
@@ -1,0 +1,68 @@
+<template>
+  <form @submit.prevent="submitForm">
+    <h6 class="text-gray-900 text-lg font-medium">
+      {{ $t('settings.customization.invoices.bcc_settings') }}
+    </h6>
+    <p class="mt-1 text-sm text-gray-500 mb-2">
+      {{ $t('settings.customization.invoices.bcc_settings_description') }}
+    </p>
+
+    <BaseInputGroup
+      :label="$t('settings.customization.invoices.invoice_email_bcc')"
+      class="mt-4"
+    >
+      <BaseInput
+        v-model="bccSettings.invoice_email_bcc"
+        type="email"
+        :placeholder="$t('settings.customization.invoices.invoice_email_bcc_placeholder')"
+      />
+    </BaseInputGroup>
+
+    <BaseButton
+      :loading="isSaving"
+      :disabled="isSaving"
+      variant="primary"
+      type="submit"
+      class="mt-4"
+    >
+      <template #left="slotProps">
+        <BaseIcon v-if="!isSaving" :class="slotProps.class" name="ArrowDownOnSquareIcon" />
+      </template>
+      {{ $t('settings.customization.save') }}
+    </BaseButton>
+  </form>
+</template>
+
+<script setup>
+import { reactive, inject, ref } from 'vue'
+import { useCompanyStore } from '@/scripts/admin/stores/company'
+
+const utils = inject('utils')
+const companyStore = useCompanyStore()
+const isSaving = ref(false)
+
+const bccSettings = reactive({
+  invoice_email_bcc: null,
+})
+
+utils.mergeSettings(bccSettings, {
+  ...companyStore.selectedCompanySettings,
+})
+
+async function submitForm() {
+  isSaving.value = true
+
+  let data = {
+    settings: {
+      invoice_email_bcc: bccSettings.invoice_email_bcc,
+    },
+  }
+
+  await companyStore.updateCompanySettings({
+    data,
+    message: 'general.setting_updated',
+  })
+
+  isSaving.value = false
+}
+</script> 


### PR DESCRIPTION
Add BCC email configuration for invoice emails

- Introduced a new setting for BCC email addresses in Company Customization settings.
- Updated the SendInvoiceMail class to include BCC functionality if configured.
- Added a new migration to initialize the BCC setting for existing companies.
- Created a new Vue component for managing BCC settings in the admin interface.
- Updated language files for English and German to include BCC-related translations.