### PR TITLE
Add Algerian Dinar (DZD) currency support

### DIFF
--- a/database/seeders/CurrenciesTableSeeder.php
+++ b/database/seeders/CurrenciesTableSeeder.php
@@ -622,6 +622,14 @@ class CurrenciesTableSeeder extends Seeder
                 'thousand_separator' => ',',
                 'decimal_separator' => '.',
             ],
+            [
+                'name' => 'Algerian Dinar',
+                'code' => 'DZD',
+                'symbol' => 'DA',
+                'precision' => '2',
+                'thousand_separator' => ',',
+                'decimal_separator' => '.',
+            ],
         ];
 
         foreach ($currencies as $currency) {


### PR DESCRIPTION
This PR adds support for the Algerian Dinar (DZD) to the list of supported currencies:

- Name: Algerian Dinar
- Code: DZD
- Symbol: DA
- Precision: 2
- Thousand Separator: ","
- Decimal Separator: "."

Closes #394

Let me know if you need any changes. Thanks!