### PR TITLE
Fixed deprecated i18n api

### DIFF
--- a/resources/scripts/admin/stores/customer.js
+++ b/resources/scripts/admin/stores/customer.js
@@ -186,7 +186,7 @@ export const useCustomerStore = (useWindow = false) => {
               this.customers.splice(index, 1)
               notificationStore.showNotification({
                 type: 'success',
-                message: global.tc('customers.deleted_message', 1),
+                message: global.t('customers.deleted_message', 1),
               })
               resolve(response)
             })
@@ -213,7 +213,7 @@ export const useCustomerStore = (useWindow = false) => {
 
               notificationStore.showNotification({
                 type: 'success',
-                message: global.tc('customers.deleted_message', 2),
+                message: global.t('customers.deleted_message', 2),
               })
               resolve(response)
             })

--- a/resources/scripts/admin/stores/estimate.js
+++ b/resources/scripts/admin/stores/estimate.js
@@ -296,7 +296,7 @@ export const useEstimateStore = (useWindow = false) => {
 
               notificationStore.showNotification({
                 type: 'success',
-                message: global.tc('estimates.deleted_message', 2),
+                message: global.t('estimates.deleted_message', 2),
               })
               resolve(response)
             })

--- a/resources/scripts/admin/stores/expense.js
+++ b/resources/scripts/admin/stores/expense.js
@@ -185,7 +185,7 @@ export const useExpenseStore = (useWindow = false) => {
 
               notificationStore.showNotification({
                 type: 'success',
-                message: global.tc('expenses.deleted_message', 1),
+                message: global.t('expenses.deleted_message', 1),
               })
               resolve(response)
             })
@@ -211,7 +211,7 @@ export const useExpenseStore = (useWindow = false) => {
               })
               notificationStore.showNotification({
                 type: 'success',
-                message: global.tc('expenses.deleted_message', 2),
+                message: global.t('expenses.deleted_message', 2),
               })
               resolve(response)
             })

--- a/resources/scripts/admin/stores/invoice.js
+++ b/resources/scripts/admin/stores/invoice.js
@@ -269,7 +269,7 @@ export const useInvoiceStore = (useWindow = false) => {
 
               notificationStore.showNotification({
                 type: 'success',
-                message: global.tc('invoices.deleted_message', 2),
+                message: global.t('invoices.deleted_message', 2),
               })
               resolve(response)
             })
@@ -493,7 +493,7 @@ export const useInvoiceStore = (useWindow = false) => {
         }
 
         let editActions = []
-        
+
         if (!isEdit) {
           await notesStore.fetchNotes()
           this.newInvoice.notes = notesStore.getDefaultNoteForType('Invoice')?.notes

--- a/resources/scripts/admin/stores/item.js
+++ b/resources/scripts/admin/stores/item.js
@@ -141,7 +141,7 @@ export const useItemStore = (useWindow = false) => {
 
               notificationStore.showNotification({
                 type: 'success',
-                message: global.tc('items.deleted_message', 1),
+                message: global.t('items.deleted_message', 1),
               })
 
               resolve(response)
@@ -169,7 +169,7 @@ export const useItemStore = (useWindow = false) => {
 
               notificationStore.showNotification({
                 type: 'success',
-                message: global.tc('items.deleted_message', 2),
+                message: global.t('items.deleted_message', 2),
               })
 
               resolve(response)

--- a/resources/scripts/admin/stores/payment.js
+++ b/resources/scripts/admin/stores/payment.js
@@ -214,7 +214,7 @@ export const usePaymentStore = (useWindow = false) => {
               })
               notificationStore.showNotification({
                 type: 'success',
-                message: global.tc('payments.deleted_message', 2),
+                message: global.t('payments.deleted_message', 2),
               })
               resolve(response)
             })

--- a/resources/scripts/admin/stores/users.js
+++ b/resources/scripts/admin/stores/users.js
@@ -152,7 +152,7 @@ export const useUsersStore = (useWindow = false) => {
               this.users.splice(index, 1)
               notificationStore.showNotification({
                 type: 'success',
-                message: global.tc('users.deleted_message', 1),
+                message: global.t('users.deleted_message', 1),
               })
               resolve(response)
             })
@@ -177,7 +177,7 @@ export const useUsersStore = (useWindow = false) => {
               const notificationStore = useNotificationStore()
               notificationStore.showNotification({
                 type: 'success',
-                message: global.tc('users.deleted_message', 2),
+                message: global.t('users.deleted_message', 2),
               })
               resolve(response)
             })


### PR DESCRIPTION
InvoiceShlef using vue-18n v11, where calling global.tc was deprecated—this PR fixes the usage of that.

https://vue-i18n.intlify.dev/guide/migration/breaking10.html#deprecate-tc-and-tc-for-legacy-api-mode