### PR TITLE
fixed czech translations

### DIFF
--- a/lang/cs.json
+++ b/lang/cs.json
@@ -131,8 +131,8 @@
       "payments": "Platby"
     },
     "chart_info": {
-      "total_sales": "Slevy",
-      "total_receipts": "Doklady",
+      "total_sales": "Vydané faktury",
+      "total_receipts": "Zaplacené faktury",
       "total_expense": "Výdaje",
       "net_income": "Čistý příjem",
       "year": "Vybrat rok"
@@ -730,7 +730,7 @@
     "no_reviews_found": "Pro tento modul zatím neexistují žádné recenze!",
     "module_not_purchased": "Modul není zakoupený",
     "module_not_found": "Modul nebyl nalezen",
-    "version_not_supported": "This module version doesn't support the current version of InvoiceShelf",
+    "version_not_supported": "Tento modul nepodporuje současnou verzi InvoiceShelf.",
     "last_updated": "Naposledy aktualizováno",
     "connect_installation": "Připojte vaši instalaci",
     "api_token_description": "Přihlaste se k {url} a připojte tuto instalaci zadáním API tokenu. Vaše zakoupené moduly se zde zobrazí po navázání připojení.",
@@ -853,7 +853,7 @@
       "notes": "Poznámky",
       "exchange_rate": "Směnný kurz",
       "address_information": "Adresa",
-      "pdf_generation": "PDF Generation"
+      "pdf_generation": "Generování PDF"
     },
     "address_information": {
       "section_description": "  Adresu můžete aktualizovat pomocí formuláře níže."
@@ -907,14 +907,14 @@
       "title": "Nastavení PDF",
       "footer_text": "Text zápatí",
       "pdf_layout": "Rozvržení PDF",
-      "pdf_configuration": "PDF Generation Settings",
-      "section_description": "Change the way PDFs are generated",
-      "driver": "PDF Driver to use",
-      "papersize": "Papersize",
-      "papersize_hint": "Papersize in width and height (ex. \"210mm 297mm\")",
-      "gotenberg_host": "Gotenberg service host",
-      "pdf_variables_save_successfully": "PDF configuration saved successfully",
-      "pdf_variables_save_error": "PDF configuration could not be saved"
+      "pdf_configuration": "Generování PDF",
+      "section_description": "Úprava možností jak jsou generovány PDF soubory.",
+      "driver": "Používaný PDF driver",
+      "papersize": "Velikost dokumentu",
+      "papersize_hint": "Velikost dokumentu v milimetrech (např. \"210mm 297mm\")",
+      "gotenberg_host": "Gotenberg server",
+      "pdf_variables_save_successfully": "Nastavení generování PDF proběhlo úspěšně.",
+      "pdf_variables_save_error": "Nastavení generování PDF nemůže být uloženo."
     },
     "company_info": {
       "company_info": "Údaje o společnosti",
@@ -1320,7 +1320,7 @@
       "backup_confirm_delete": "Tuto zálohu nebudete moci obnovit",
       "path": "cesta",
       "new_disk": "Nový disk",
-      "created_at": "vytvořeno v",
+      "created_at": "vytvořeno",
       "size": "velikost",
       "dropbox": "dropbox",
       "local": "místní",
@@ -1434,7 +1434,7 @@
     "street": "Ulice1 | Ulice2",
     "phone": "Telefon",
     "zip_code": "PSČ",
-    "go_back": "Jít zpět",
+    "go_back": "Zpět",
     "currency": "Měna",
     "language": "Jazyk",
     "time_zone": "Časové pásmo",
@@ -1506,7 +1506,7 @@
     },
     "req": {
       "system_req": "Systémové požadavky",
-      "php_req_version": "Php (požadovaná verze {version})",
+      "php_req_version": "PHP (požadovaná verze {version})",
       "check_req": "Zkontrolujte požadavky",
       "system_req_desc": "InvoiceShelf má několik požadavků na server. Ujistěte se, že váš server má požadovanou php verzi a všechna níže uvedená rozšíření."
     },
@@ -1600,13 +1600,13 @@
   "pdf_invoice_label": "Faktura",
   "pdf_invoice_number": "Číslo faktury",
   "pdf_invoice_date": "Datum fakturace",
-  "pdf_invoice_due_date": "Due Date",
+  "pdf_invoice_due_date": "Datum splatnosti",
   "pdf_notes": "Poznámky",
   "pdf_items_label": "Položky",
   "pdf_quantity_label": "Množství",
   "pdf_price_label": "Cena",
   "pdf_discount_label": "Sleva",
-  "pdf_amount_label": "Množství",
+  "pdf_amount_label": "Celkem",
   "pdf_subtotal": "Mezisoučet",
   "pdf_total": "Celkem",
   "pdf_payment_label": "Platba",


### PR DESCRIPTION
Fixed czech translations

 - some of english tags were not translated to czech language (pdf_invoice_due_date, version_not_supported, pdf_generation...)
 - some tags I updated to express a clear message (created_at, go_back)
 - fixed wrong translates
   - total_sales was translated as "Discount"
   - total_receipts - translate was fine, but for clearer communication, I translated it as "paid invoices"
   - pdf_amount_label - translate ment quantity, I changed meaning to "total"