### PR TITLE
Fix: Use amounts in base currency for customer charts

### DIFF
--- a/app/Http/Controllers/V1/Admin/Customer/CustomerStatsController.php
+++ b/app/Http/Controllers/V1/Admin/Customer/CustomerStatsController.php
@@ -61,7 +61,7 @@ class CustomerStatsController extends Controller
                 )
                     ->whereCompany()
                     ->whereCustomer($customer->id)
-                    ->sum('total') ?? 0
+                    ->sum('base_total') ?? 0
             );
             array_push(
                 $expenseTotals,
@@ -71,7 +71,7 @@ class CustomerStatsController extends Controller
                 )
                     ->whereCompany()
                     ->whereUser($customer->id)
-                    ->sum('amount') ?? 0
+                    ->sum('base_amount') ?? 0
             );
             array_push(
                 $receiptTotals,
@@ -81,7 +81,7 @@ class CustomerStatsController extends Controller
                 )
                     ->whereCompany()
                     ->whereCustomer($customer->id)
-                    ->sum('amount') ?? 0
+                    ->sum('base_amount') ?? 0
             );
             array_push(
                 $netProfits,
@@ -103,21 +103,21 @@ class CustomerStatsController extends Controller
         )
             ->whereCompany()
             ->whereCustomer($customer->id)
-            ->sum('total');
+            ->sum('base_total');
         $totalReceipts = Payment::whereBetween(
             'payment_date',
             [$startDate->format('Y-m-d'), $start->format('Y-m-d')]
         )
             ->whereCompany()
             ->whereCustomer($customer->id)
-            ->sum('amount');
+            ->sum('base_amount');
         $totalExpenses = Expense::whereBetween(
             'expense_date',
             [$startDate->format('Y-m-d'), $start->format('Y-m-d')]
         )
             ->whereCompany()
             ->whereUser($customer->id)
-            ->sum('amount');
+            ->sum('base_amount');
         $netProfit = (int) $totalReceipts - (int) $totalExpenses;
 
         $chartData = [


### PR DESCRIPTION
Previously, the customer chart used the total/amount fields to calculate net profits/expenses/etc. 

If the currency for an expense (for example) differed from the base currency of the company, the chart would display the amount in the "original" currency without conversion.
For example, when creating an expense for a customer with the currency JPY and amount 1000 (roughly 7 USD) while the base currency is USD, the customer chart suddenly registers a net profit of -1000 USD (instead of -7 USD).

This change addresses the issue by always using the base currency field which is also used by the main dashboard chart.

This issue was not previously reported.