### PR TITLE
Fix: Weird gap in invoice items description

### DIFF
--- a/resources/views/app/pdf/invoice/invoice1.blade.php
+++ b/resources/views/app/pdf/invoice/invoice1.blade.php
@@ -201,6 +201,7 @@
             color: #595959;
             font-size: 9px;
             line-height: 12px;
+            display: block;
         }
 
         /* -- Total Display Table -- */

--- a/resources/views/app/pdf/invoice/invoice2.blade.php
+++ b/resources/views/app/pdf/invoice/invoice2.blade.php
@@ -244,6 +244,7 @@
             color: #595959;
             font-size: 9px;
             line-height: 12px;
+            display: block;
         }
 
         /* -- Total Display Table -- */

--- a/resources/views/app/pdf/invoice/invoice3.blade.php
+++ b/resources/views/app/pdf/invoice/invoice3.blade.php
@@ -173,6 +173,7 @@
             color: #595959;
             font-size: 9px;
             line-height: 12px;
+            display: block;
         }
 
         .item-cell-table-hr {


### PR DESCRIPTION
fix: Ensure invoice item display is block for better layout. Gets rids of the weird extra gap between last line and the line above it.

<img width="748" height="143" alt="2025-08-22_18h08_49" src="https://github.com/user-attachments/assets/b1786240-f996-4151-ada9-38d8b0227b91" />
