### PR TITLE
Temperately hide modules tab while Module Management is developed

### DIFF
--- a/config/invoiceshelf.php
+++ b/config/invoiceshelf.php
@@ -374,7 +374,7 @@ return [
         ],
         // TODO: remove env check once the module management os implemented.
         ...(
-            env("APP_ENV", "production") == "development" ? [
+            env('APP_ENV', 'production') == 'development' ? [
                 [
                     'title' => 'navigation.modules',
                     'group' => 3,
@@ -384,7 +384,7 @@ return [
                     'owner_only' => true,
                     'ability' => '',
                     'model' => '',
-                ]
+                ],
             ] : []
         ),
         [

--- a/config/invoiceshelf.php
+++ b/config/invoiceshelf.php
@@ -372,16 +372,21 @@ return [
             'ability' => 'view-expense',
             'model' => Expense::class,
         ],
-        [
-            'title' => 'navigation.modules',
-            'group' => 3,
-            'link' => '/admin/modules',
-            'icon' => 'PuzzlePieceIcon',
-            'name' => 'Modules',
-            'owner_only' => true,
-            'ability' => '',
-            'model' => '',
-        ],
+        // TODO: remove env check once the module management os implemented.
+        ...(
+            env("APP_ENV", "production") == "development" ? [
+                [
+                    'title' => 'navigation.modules',
+                    'group' => 3,
+                    'link' => '/admin/modules',
+                    'icon' => 'PuzzlePieceIcon',
+                    'name' => 'Modules',
+                    'owner_only' => true,
+                    'ability' => '',
+                    'model' => '',
+                ]
+            ] : []
+        ),
         [
             'title' => 'navigation.users',
             'group' => 3,


### PR DESCRIPTION
Adds a check during `main_menu` item population to determine if the app is running in development or production, and conditionally adds/removes the modules tab to prevent confusion caused by the API requirement, as we currently only have two modules.