### PR TITLE
Fix language file conflicts

### DIFF
--- a/config/invoiceshelf.php
+++ b/config/invoiceshelf.php
@@ -53,6 +53,7 @@ return [
     'languages' => [
         ['code' => 'ar', 'name' => 'Arabic'],
         ['code' => 'bg', 'name' => 'Bulgarian'],
+        ['code' => 'zh_CN', 'name' => 'Chinese (Simplified)'],
         ['code' => 'zh', 'name' => 'Chinese (Traditional)'],
         ['code' => 'hr', 'name' => 'Croatian'],
         ['code' => 'cs', 'name' => 'Czech'],

--- a/resources/scripts/helpers/language-loader.js
+++ b/resources/scripts/helpers/language-loader.js
@@ -19,7 +19,12 @@ export async function loadLanguage(locale) {
 
   try {
     // Dynamic import of language file
-    const languageModule = await import(`../../../lang/${locale === 'pt_BR' ? 'pt-br' : locale}.json`)
+    const fileMap = {
+      'zh_CN': 'zh-cn',
+      'pt_BR': 'pt-br',
+    }
+    const fileName = fileMap[locale] || locale;
+    const languageModule = await import(`../../../lang/${fileName}.json`)
     const messages = languageModule.default || languageModule
 
     // Cache the loaded language


### PR DESCRIPTION
This PR fixes language file conflicts, for instance, both Portuguese and Portuguese (Brazilian) were pushed to `pt.json` ignoring `pt-br.json`. Changes in Crowdin to Portuguese (Brazilian) should now end in `pt-br.json` correctly. 