### PR TITLE
Fix: Actually display company currency symbol / total receipts for customer charts

### DIFF
--- a/resources/scripts/admin/views/customers/partials/CustomerChart.vue
+++ b/resources/scripts/admin/views/customers/partials/CustomerChart.vue
@@ -74,7 +74,7 @@
             style="color: #00c99c"
           >
             <BaseFormatMoney
-              :amount="chartData.totalExpenses"
+              :amount="chartData.totalReceipts"
               :currency="companyStore.selectedCompanyCurrency"
             />
           </span>


### PR DESCRIPTION
Related to draft #403.
The mentioned pull request was incomplete, the current state would show amounts in base currency but not use the base/company currency symbols/notation. This change addresses the issue.