### PR TITLE
Ignore devcontainer dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Homestead.yaml
 .rnd
 /.expo
 /.vscode
+/.devcontainer
 .gitkeep
 /public/docs
 /.scribe


### PR DESCRIPTION
Adds an ignore rule to .gitignore for `/.devcontainer`