### PR TITLE
Fix aggregates for customers using withSum() (SQL-portable, no DB mode tweaks)

### DIFF
--- a/app/Http/Controllers/V1/Admin/Customer/CustomersController.php
+++ b/app/Http/Controllers/V1/Admin/Customer/CustomersController.php
@@ -8,7 +8,6 @@ use App\Http\Requests\DeleteCustomersRequest;
 use App\Http\Resources\CustomerResource;
 use App\Models\Customer;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class CustomersController extends Controller
 {


### PR DESCRIPTION
---

# Fix: replace `LEFT JOIN + GROUP BY` with Eloquent `withSum()` for customer aggregates

## Summary

This PR replaces the customer aggregates query that relied on `LEFT JOIN + GROUP BY customers.id + SUM(...)` with Eloquent’s `withSum()` helpers.
Benefits:

* Works with default SQL modes (e.g. MySQL/MariaDB with `ONLY_FULL_GROUP_BY`) and PostgreSQL
* Keeps the same API response fields via aliases (`base_due_amount`, `due_amount`)
* Simpler, more readable query; pagination/count stay reliable

---

## Context / Problem

The current query selects `customers.*` while grouping only by `customers.id`. With strict SQL modes (e.g. MariaDB 10.9 default `ONLY_FULL_GROUP_BY`), this raises:

```
SQLSTATE[42000]: Syntax error or access violation: 1055
'customers.prefix' isn't in GROUP BY
```

---

## What I changed

**Before**

```php
$customers = Customer::with('creator')
    ->whereCompany()
    ->applyFilters($request->all())
    ->select(
        'customers.*',
        DB::raw('sum(invoices.base_due_amount) as base_due_amount'),
        DB::raw('sum(invoices.due_amount) as due_amount'),
    )
    ->groupBy('customers.id')
    ->leftJoin('invoices', 'customers.id', '=', 'invoices.customer_id')
    ->paginateData($limit);
```

**After**

```php
$customers = Customer::with('creator')
    ->whereCompany()
    ->applyFilters($request->all())
    ->withSum('invoices as base_due_amount', 'base_due_amount')
    ->withSum('invoices as due_amount', 'due_amount')
    ->paginateData($limit);
```

* Uses Laravel’s aggregate helpers to generate correlated subqueries (no global `GROUP BY`).
* Aliases preserve the original field names: `base_due_amount`, `due_amount`.

---

## How to test

1. Seed or create a company with multiple customers and multiple invoices per customer.
2. Hit the customers listing endpoint with/without filters and with pagination.
3. Verify:

   * Each customer row includes `base_due_amount` and `due_amount`.
   * Sums match the invoices per customer (customers with no invoices should return `null`/`0` depending on the resource normalization).
   * Pagination and sorting (if any uses these fields) still work.

> If sorting by these sums is used, `orderBy('due_amount')` / `orderByDesc('due_amount')` continues to work since `withSum` exposes them as selectable aliases.

---

## Backward compatibility

* **No breaking changes**: response field names remain the same (`base_due_amount`, `due_amount`).
* No DB-specific configuration needed (works on MySQL/MariaDB/PostgreSQL with default modes).

---

## Documentation reference

* Laravel 12 — Eloquent Relationships → Aggregating Related Models → Other Aggregate Functions (`withSum`, `withAvg`, …)

---

## Self-review checklist

* [x] Code compiles and passes basic manual checks
* [x] API response shape unchanged (same field names/aliases)
* [x] No reliance on DB-specific SQL modes
* [x] Pagination and filters still behave as before
* [x] Comments and variable names are clear

---

## Type of change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature
* [ ] Refactor
* [ ] Documentation

---

Thanks for the review! If you prefer an alternative using `leftJoinSub()` with a pre-aggregated invoices subquery, I can add that variant as well.
