### PR TITLE
Add Interac e‑Transfer IMAP sync with automatic payment creation

### DIFF
--- a/app/Console/Commands/SyncInteracETransfersCommand.php
+++ b/app/Console/Commands/SyncInteracETransfersCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\InteracETransferService;
+use Illuminate\Console\Command;
+
+class SyncInteracETransfersCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'interac:sync {--company= : Limit sync to a single company id}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sync Interac e-Transfer inboxes and create payments automatically';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(InteracETransferService $service): int
+    {
+        $companyId = $this->option('company');
+        $results = $service->sync($companyId ? (int) $companyId : null);
+
+        if (! $results) {
+            $this->warn('No companies were processed. Is the IMAP extension enabled?');
+
+            return self::SUCCESS;
+        }
+
+        foreach ($results as $companyId => $result) {
+            $this->line(sprintf(
+                'Company %s -> status: %s, checked: %s, payments created: %s',
+                $companyId,
+                $result['status'] ?? 'unknown',
+                $result['messages_checked'] ?? 0,
+                $result['payments_created'] ?? 0
+            ));
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/V1/Admin/Payment/SyncInteracETransferController.php
+++ b/app/Http/Controllers/V1/Admin/Payment/SyncInteracETransferController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\V1\Admin\Payment;
+
+use App\Http\Controllers\Controller;
+use App\Models\Payment;
+use App\Services\InteracETransferService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SyncInteracETransferController extends Controller
+{
+    /**
+     * Trigger a sync for the current company.
+     */
+    public function __invoke(Request $request, InteracETransferService $service): JsonResponse
+    {
+        $this->authorize('create', Payment::class);
+
+        $companyId = (int) $request->header('company');
+        $result = $service->sync($companyId)[$companyId] ?? [];
+
+        return response()->json([
+            'success' => true,
+            'data' => $result,
+        ]);
+    }
+}

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -178,6 +178,7 @@ class Company extends Model implements HasMedia
         PaymentMethod::create(['name' => 'Check', 'company_id' => $this->id]);
         PaymentMethod::create(['name' => 'Credit Card', 'company_id' => $this->id]);
         PaymentMethod::create(['name' => 'Bank Transfer', 'company_id' => $this->id]);
+        PaymentMethod::create(['name' => 'Interac e-Transfer', 'company_id' => $this->id]);
     }
 
     public function setupDefaultUnits()

--- a/app/Models/CompanySetting.php
+++ b/app/Models/CompanySetting.php
@@ -33,7 +33,7 @@ class CompanySetting extends Model
                 [
                     'option' => $key,
                     'company_id' => $company_id,
-                    'value' => $value,
+                    'value' => $value ?? '',
                 ]
             );
         }

--- a/app/Models/InteracETransferLog.php
+++ b/app/Models/InteracETransferLog.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class InteracETransferLog extends Model
+{
+    use HasFactory;
+
+    protected $guarded = ['id'];
+
+    protected function casts(): array
+    {
+        return [
+            'meta' => 'array',
+        ];
+    }
+
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function payment(): BelongsTo
+    {
+        return $this->belongsTo(Payment::class);
+    }
+}

--- a/app/Services/InteracETransferService.php
+++ b/app/Services/InteracETransferService.php
@@ -4,8 +4,8 @@ namespace App\Services;
 
 use App\Models\Company;
 use App\Models\CompanySetting;
-use App\Models\Customer;
 use App\Models\Currency;
+use App\Models\Customer;
 use App\Models\InteracETransferLog;
 use App\Models\Payment;
 use App\Models\PaymentMethod;
@@ -333,8 +333,8 @@ class InteracETransferService
      */
     protected function createPayment(Company $company, Customer $customer, int $paymentMethodId, array $paymentInfo): Payment
     {
-        $serial = (new SerialNumberFormatter())
-            ->setModel(new Payment())
+        $serial = (new SerialNumberFormatter)
+            ->setModel(new Payment)
             ->setCompany($company->id)
             ->setCustomer($customer->id)
             ->setNextNumbers();

--- a/app/Services/InteracETransferService.php
+++ b/app/Services/InteracETransferService.php
@@ -1,0 +1,642 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Company;
+use App\Models\CompanySetting;
+use App\Models\Customer;
+use App\Models\Currency;
+use App\Models\InteracETransferLog;
+use App\Models\Payment;
+use App\Models\PaymentMethod;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Vinkla\Hashids\Facades\Hashids;
+
+class InteracETransferService
+{
+    private string $mailboxPrefix = '';
+
+    /**
+     * Sync e-transfer notifications for all enabled companies or a specific company.
+     */
+    public function sync(?int $companyId = null): array
+    {
+        if (! function_exists('imap_open')) {
+            Log::warning('Interac e-Transfer sync skipped because PHP IMAP extension is missing.');
+
+            return [];
+        }
+
+        $companies = $this->eligibleCompanies($companyId);
+
+        $results = [];
+        foreach ($companies as $company) {
+            $results[$company->id] = $this->syncCompany($company);
+        }
+
+        return $results;
+    }
+
+    /**
+     * Attempt to connect to the mailbox using provided settings.
+     */
+    public function testConnection(array $settings): array
+    {
+        if (! function_exists('imap_open')) {
+            return [
+                'status' => 'missing_extension',
+            ];
+        }
+
+        if (! $settings['enabled']) {
+            return [
+                'status' => 'disabled',
+            ];
+        }
+
+        $connection = $this->connect($settings);
+
+        if (! $connection) {
+            return [
+                'status' => 'connection_failed',
+                'errors' => imap_errors() ?: [],
+            ];
+        }
+
+        $isAlive = @imap_ping($connection);
+
+        @imap_close($connection);
+
+        return [
+            'status' => $isAlive ? 'ok' : 'connection_failed',
+        ];
+    }
+
+    /**
+     * Merge request payload into resolved settings for connection testing.
+     */
+    public function mergeSettingsFromPayload(Company $company, array $payload): array
+    {
+        $settings = $this->getSettings($company);
+
+        $map = [
+            'enabled' => 'interac_enabled',
+            'host' => 'interac_imap_host',
+            'port' => 'interac_imap_port',
+            'encryption' => 'interac_imap_encryption',
+            'username' => 'interac_imap_username',
+            'password' => 'interac_imap_password',
+            'folder' => 'interac_imap_folder',
+            'validate_cert' => 'interac_imap_validate_cert',
+            'mark_as_read' => 'interac_imap_mark_as_read',
+            'move_to' => 'interac_imap_move_to',
+            'sender_filter' => 'interac_sender_filter',
+        ];
+
+        foreach ($map as $key => $option) {
+            if (! array_key_exists($option, $payload)) {
+                continue;
+            }
+
+            $settings[$key] = match ($key) {
+                'enabled', 'mark_as_read', 'validate_cert' => filter_var($payload[$option], FILTER_VALIDATE_BOOLEAN),
+                'port' => (int) $payload[$option],
+                default => $payload[$option],
+            };
+        }
+
+        return $settings;
+    }
+
+    /**
+     * Fetch companies with Interac automation enabled.
+     */
+    protected function eligibleCompanies(?int $companyId = null): Collection
+    {
+        $query = Company::query();
+
+        if ($companyId) {
+            $query->where('id', $companyId);
+        }
+
+        $query->whereHas('settings', function ($settings) {
+            $settings->where('option', 'interac_enabled')
+                ->whereIn('value', ['1', 1, 'true', true, 'on']);
+        });
+
+        return $query->get();
+    }
+
+    /**
+     * Sync messages for a single company.
+     */
+    public function syncCompany(Company $company): array
+    {
+        $settings = $this->getSettings($company);
+
+        if (! $settings['enabled']) {
+            return ['status' => 'disabled'];
+        }
+
+        if (! $settings['host'] || ! $settings['username'] || ! $settings['password']) {
+            return ['status' => 'missing_settings'];
+        }
+
+        $lock = Cache::lock('interac-sync-'.$company->id, 120);
+
+        if (! $lock->get()) {
+            return ['status' => 'locked'];
+        }
+
+        $checked = 0;
+        $created = 0;
+        $connection = null;
+
+        try {
+            $connection = $this->connect($settings);
+
+            if (! $connection) {
+                Log::warning('Interac e-Transfer connection failed', [
+                    'company_id' => $company->id,
+                    'host' => $settings['host'],
+                    'errors' => imap_errors(),
+                ]);
+
+                return ['status' => 'connection_failed'];
+            }
+
+            $uids = $this->search($connection, $settings['sender_filter']);
+
+            foreach ($uids as $uid) {
+                $checked++;
+                $result = $this->processMessage($connection, (int) $uid, $company, $settings);
+
+                if ($result) {
+                    $created++;
+                }
+            }
+
+            imap_expunge($connection);
+        } finally {
+            if ($connection) {
+                imap_close($connection);
+            }
+            optional($lock)->release();
+        }
+
+        return [
+            'status' => 'ok',
+            'messages_checked' => $checked,
+            'payments_created' => $created,
+        ];
+    }
+
+    /**
+     * Open the IMAP connection.
+     */
+    protected function connect(array $settings)
+    {
+        $flags = match ($settings['encryption']) {
+            'ssl' => '/ssl',
+            'tls' => '/tls',
+            default => '/notls',
+        };
+
+        $validateFlag = $settings['validate_cert'] ? '' : '/novalidate-cert';
+
+        $this->mailboxPrefix = sprintf(
+            '{%s:%d/imap%s%s}',
+            $settings['host'],
+            $settings['port'],
+            $flags,
+            $validateFlag
+        );
+
+        return @imap_open(
+            $this->mailboxPrefix.$settings['folder'],
+            $settings['username'],
+            $settings['password']
+        );
+    }
+
+    /**
+     * Find unseen messages matching the sender filter.
+     */
+    protected function search($connection, ?string $senderFilter): array
+    {
+        $criteria = 'UNSEEN';
+
+        if ($senderFilter) {
+            $criteria .= ' FROM "'.$senderFilter.'"';
+        }
+
+        $messages = imap_search($connection, $criteria, SE_UID);
+
+        return $messages ?: [];
+    }
+
+    /**
+     * Process a single email.
+     */
+    protected function processMessage($connection, int $uid, Company $company, array $settings): bool
+    {
+        $overview = imap_fetch_overview($connection, (string) $uid, FT_UID);
+        if (! $overview || ! isset($overview[0])) {
+            $this->finalizeMessage($connection, $uid, $settings, null);
+
+            return false;
+        }
+
+        $meta = $overview[0];
+
+        $messageId = $meta->message_id ?? null;
+        $senderHeader = $meta->from ?? '';
+        $subject = $meta->subject ?? '';
+        $sentAt = $meta->date ?? null;
+        $senderParts = imap_rfc822_parse_adrlist($senderHeader, 'noreply@example.com')[0] ?? null;
+        $senderEmail = $senderParts?->mailbox && $senderParts?->host ? "{$senderParts->mailbox}@{$senderParts->host}" : null;
+        $senderName = $senderParts?->personal ?: $senderEmail;
+
+        $htmlBody = $this->getHtmlBody($connection, $uid);
+
+        $paymentInfo = $this->parsePaymentInfo($htmlBody, $subject, $senderName);
+
+        if (! $paymentInfo) {
+            $this->finalizeMessage($connection, $uid, $settings, $senderName);
+
+            return false;
+        }
+
+        if ($this->alreadyProcessed($company, $paymentInfo['reference'], $messageId)) {
+            $this->finalizeMessage($connection, $uid, $settings, $senderName);
+
+            return false;
+        }
+
+        $customer = $this->findOrCreateCustomer(
+            $company,
+            $paymentInfo['sender'] ?? $senderName ?? 'Interac Customer',
+            $senderEmail
+        );
+
+        $paymentMethodId = $this->getPaymentMethod($company);
+
+        $payment = $this->createPayment(
+            $company,
+            $customer,
+            $paymentMethodId,
+            $paymentInfo
+        );
+
+        InteracETransferLog::create([
+            'company_id' => $company->id,
+            'payment_id' => $payment->id,
+            'reference' => $paymentInfo['reference'],
+            'message_id' => $messageId,
+            'sender_name' => $customer->name,
+            'sender_email' => $senderEmail,
+            'amount' => $paymentInfo['amount_cents'],
+            'meta' => [
+                'subject' => $subject,
+                'sent_at' => $sentAt,
+                'uid' => $uid,
+            ],
+        ]);
+
+        $this->finalizeMessage($connection, $uid, $settings, $customer->name);
+
+        return true;
+    }
+
+    /**
+     * Mark the message and optionally move to a folder.
+     */
+    protected function finalizeMessage($connection, int $uid, array $settings, ?string $customerName): void
+    {
+        if ($settings['mark_as_read']) {
+            @imap_setflag_full($connection, (string) $uid, '\\Seen', ST_UID);
+        }
+
+        if ($settings['move_to']) {
+            $folder = $this->buildFolderName($settings['move_to'], $customerName);
+
+            $this->moveToFolder($connection, $uid, $folder);
+        }
+    }
+
+    /**
+     * Create a payment record.
+     */
+    protected function createPayment(Company $company, Customer $customer, int $paymentMethodId, array $paymentInfo): Payment
+    {
+        $serial = (new SerialNumberFormatter())
+            ->setModel(new Payment())
+            ->setCompany($company->id)
+            ->setCustomer($customer->id)
+            ->setNextNumbers();
+
+        $payment = Payment::create([
+            'payment_number' => $serial->getNextNumber(),
+            'payment_date' => $paymentInfo['payment_date'],
+            'amount' => $paymentInfo['amount_cents'],
+            'payment_method_id' => $paymentMethodId,
+            'customer_id' => $customer->id,
+            'exchange_rate' => 1,
+            'base_amount' => $paymentInfo['amount_cents'],
+            'currency_id' => $customer->currency_id,
+            'company_id' => $company->id,
+            'creator_id' => $company->owner_id,
+            'notes' => 'Interac e-Transfer payment (Ref: '.$paymentInfo['reference'].')',
+        ]);
+
+        $payment->unique_hash = Hashids::connection(Payment::class)->encode($payment->id);
+        $payment->sequence_number = $serial->nextSequenceNumber;
+        $payment->customer_sequence_number = $serial->nextCustomerSequenceNumber;
+        $payment->save();
+
+        return $payment;
+    }
+
+    /**
+     * Ensure Interac payment method exists.
+     */
+    protected function getPaymentMethod(Company $company): int
+    {
+        $method = PaymentMethod::where('company_id', $company->id)
+            ->whereRaw('LOWER(name) = ?', ['interac e-transfer'])
+            ->first();
+
+        if (! $method) {
+            $method = PaymentMethod::create([
+                'name' => 'Interac e-Transfer',
+                'company_id' => $company->id,
+            ]);
+        }
+
+        return $method->id;
+    }
+
+    /**
+     * Create or locate the sender as a customer.
+     */
+    protected function findOrCreateCustomer(Company $company, string $name, ?string $email): Customer
+    {
+        $customer = Customer::where('company_id', $company->id)
+            ->whereRaw('LOWER(name) = ?', [Str::lower($name)])
+            ->first();
+
+        $currencyId = CompanySetting::getSetting('currency', $company->id)
+            ?: $customer?->currency_id
+            ?: Currency::first()?->id;
+        $currencyId = (int) $currencyId;
+
+        if (! $customer) {
+            $customer = Customer::create([
+                'name' => $name,
+                'email' => $email,
+                'currency_id' => $currencyId,
+                'company_id' => $company->id,
+                'enable_portal' => false,
+                'creator_id' => $company->owner_id,
+            ]);
+        } elseif (! $customer->currency_id) {
+            $customer->currency_id = $currencyId;
+            $customer->save();
+        }
+
+        return $customer;
+    }
+
+    /**
+     * Avoid processing the same email twice.
+     */
+    protected function alreadyProcessed(Company $company, string $reference, ?string $messageId): bool
+    {
+        return InteracETransferLog::where('company_id', $company->id)
+            ->where(function ($query) use ($reference, $messageId) {
+                $query->where('reference', $reference);
+                if ($messageId) {
+                    $query->orWhere('message_id', $messageId);
+                }
+            })
+            ->exists();
+    }
+
+    /**
+     * Parse payment details from HTML.
+     */
+    protected function parsePaymentInfo(?string $html, string $subject, ?string $sender): ?array
+    {
+        if (! $html) {
+            return null;
+        }
+
+        $plain = preg_replace('/\s+/', ' ', strip_tags($html));
+
+        $amount = null;
+        if (preg_match('/\\$\\s*([0-9][0-9,]*(?:\\.\\d{1,2})?)/', $plain, $amountMatch)) {
+            $amount = (float) str_replace(',', '', $amountMatch[1]);
+        } elseif (preg_match('/([0-9][0-9,]*(?:\\.\\d{1,2})?)\\s*(?:CAD)?/i', $plain, $amountMatch)) {
+            $amount = (float) str_replace(',', '', $amountMatch[1]);
+        }
+
+        if (! $amount) {
+            return null;
+        }
+
+        $reference = null;
+        if (preg_match('/Reference Number:?\\s*([A-Za-z0-9\\-]+)/i', $plain, $refMatch)) {
+            $reference = $refMatch[1];
+        } elseif (preg_match('/Ref[:#]?\\s*([A-Za-z0-9\\-]+)/i', $subject, $refMatch)) {
+            $reference = $refMatch[1];
+        }
+
+        if (! $reference) {
+            return null;
+        }
+
+        $date = null;
+        if (preg_match('/Date:?\\s*([A-Za-z]{3,9}\\s+\\d{1,2},\\s+\\d{4})/i', $plain, $dateMatch)) {
+            try {
+                $date = Carbon::parse($dateMatch[1])->format('Y-m-d');
+            } catch (\Throwable $th) {
+                $date = null;
+            }
+        }
+
+        if (! $sender && preg_match('/Sent From:?\\s*([^$]+?)(?:Date|Reference|$)/i', $plain, $senderMatch)) {
+            $sender = trim($senderMatch[1]);
+        }
+
+        return [
+            'amount_cents' => (int) round($amount * 100),
+            'reference' => $reference,
+            'payment_date' => $date ?? now()->toDateString(),
+            'sender' => $sender,
+        ];
+    }
+
+    /**
+     * Fetch and decode the HTML body.
+     */
+    protected function getHtmlBody($connection, int $uid): ?string
+    {
+        $structure = imap_fetchstructure($connection, (string) $uid, FT_UID);
+
+        if (! $structure) {
+            return null;
+        }
+
+        if ($structure->type === TYPETEXT && strtolower($structure->subtype ?? '') === 'html') {
+            return $this->decodeBody(imap_body($connection, (string) $uid, FT_UID | FT_PEEK), $structure->encoding ?? 0);
+        }
+
+        if ($structure->type === TYPETEXT && strtolower($structure->subtype ?? '') === 'plain') {
+            return $this->decodeBody(imap_body($connection, (string) $uid, FT_UID | FT_PEEK), $structure->encoding ?? 0);
+        }
+
+        if (! isset($structure->parts)) {
+            return null;
+        }
+
+        $plainFallback = null;
+
+        foreach ($structure->parts as $index => $part) {
+            $partNumber = (string) ($index + 1);
+
+            if (strtolower($part->subtype ?? '') === 'html') {
+                $body = imap_fetchbody($connection, (string) $uid, $partNumber, FT_UID | FT_PEEK);
+
+                return $this->decodeBody($body, $part->encoding ?? 0);
+            }
+
+            if (strtolower($part->subtype ?? '') === 'plain') {
+                $body = imap_fetchbody($connection, (string) $uid, $partNumber, FT_UID | FT_PEEK);
+                $plainFallback = $this->decodeBody($body, $part->encoding ?? 0);
+            }
+
+            if (isset($part->parts) && count($part->parts)) {
+                foreach ($part->parts as $subIndex => $subPart) {
+                    $subPartNumber = $partNumber.'.'.($subIndex + 1);
+
+                    if (strtolower($subPart->subtype ?? '') === 'html') {
+                        $body = imap_fetchbody($connection, (string) $uid, $subPartNumber, FT_UID | FT_PEEK);
+
+                        return $this->decodeBody($body, $subPart->encoding ?? 0);
+                    }
+
+                    if (strtolower($subPart->subtype ?? '') === 'plain') {
+                        $body = imap_fetchbody($connection, (string) $uid, $subPartNumber, FT_UID | FT_PEEK);
+                        $plainFallback = $this->decodeBody($body, $subPart->encoding ?? 0);
+                    }
+                }
+            }
+        }
+
+        return $plainFallback;
+    }
+
+    /**
+     * Decode a raw IMAP body based on encoding.
+     */
+    protected function decodeBody(?string $body, int $encoding): ?string
+    {
+        if ($body === null) {
+            return null;
+        }
+
+        return match ($encoding) {
+            ENCBASE64 => base64_decode($body),
+            ENCQUOTEDPRINTABLE => quoted_printable_decode($body),
+            default => $body,
+        };
+    }
+
+    /**
+     * Build a sanitized folder name from template.
+     */
+    protected function buildFolderName(string $template, ?string $customerName): string
+    {
+        $safeName = $customerName ? Str::slug($customerName, '_') : 'interac';
+
+        if (str_contains($template, '{customer}')) {
+            return str_replace('{customer}', $safeName, $template);
+        }
+
+        return trim($template.'-'.$safeName, '-');
+    }
+
+    /**
+     * Move message to a mailbox, creating it when needed.
+     */
+    protected function moveToFolder($connection, int $uid, string $folder): void
+    {
+        if (! $folder) {
+            return;
+        }
+
+        $encodedFolder = imap_utf7_encode($this->mailboxPrefix.$folder);
+
+        if (! @imap_createmailbox($connection, $encodedFolder)) {
+            // ignore if it already exists
+        }
+
+        @imap_mail_move($connection, (string) $uid, $folder, CP_UID);
+    }
+
+    /**
+     * Resolve company level settings with defaults.
+     */
+    protected function getSettings(Company $company): array
+    {
+        $keys = [
+            'interac_enabled',
+            'interac_imap_host',
+            'interac_imap_port',
+            'interac_imap_encryption',
+            'interac_imap_username',
+            'interac_imap_password',
+            'interac_imap_folder',
+            'interac_imap_validate_cert',
+            'interac_imap_mark_as_read',
+            'interac_imap_move_to',
+            'interac_sender_filter',
+        ];
+
+        $raw = CompanySetting::getSettings($keys, $company->id)->toArray();
+
+        $defaults = [
+            'interac_enabled' => false,
+            'interac_imap_host' => null,
+            'interac_imap_port' => 993,
+            'interac_imap_encryption' => 'ssl',
+            'interac_imap_username' => null,
+            'interac_imap_password' => null,
+            'interac_imap_folder' => 'INBOX',
+            'interac_imap_validate_cert' => true,
+            'interac_imap_mark_as_read' => true,
+            'interac_imap_move_to' => '',
+            'interac_sender_filter' => 'notify@payments.interac.ca',
+        ];
+
+        $settings = array_merge($defaults, $raw);
+
+        return [
+            'enabled' => filter_var($settings['interac_enabled'], FILTER_VALIDATE_BOOLEAN),
+            'host' => $settings['interac_imap_host'],
+            'port' => (int) $settings['interac_imap_port'],
+            'encryption' => $settings['interac_imap_encryption'] ?: 'ssl',
+            'username' => $settings['interac_imap_username'],
+            'password' => $settings['interac_imap_password'],
+            'folder' => $settings['interac_imap_folder'] ?: 'INBOX',
+            'validate_cert' => filter_var($settings['interac_imap_validate_cert'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true,
+            'mark_as_read' => filter_var($settings['interac_imap_mark_as_read'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true,
+            'move_to' => $settings['interac_imap_move_to'] ?? '',
+            'sender_filter' => $settings['interac_sender_filter'] ?? null,
+        ];
+    }
+}

--- a/config/invoiceshelf.php
+++ b/config/invoiceshelf.php
@@ -231,6 +231,16 @@ return [
             'model' => Payment::class,
         ],
         [
+            'title' => 'settings.menu_title.interac_e_transfer',
+            'group' => '',
+            'name' => 'Interac e-Transfer',
+            'link' => '/admin/settings/interac-e-transfer',
+            'icon' => 'InboxArrowDownIcon',
+            'owner_only' => true,
+            'ability' => 'create-payment',
+            'model' => Payment::class,
+        ],
+        [
             'title' => 'settings.menu_title.custom_fields',
             'group' => '',
             'name' => 'Custom fields',

--- a/database/migrations/2025_12_18_000000_add_interac_e_transfer_default_payment_method.php
+++ b/database/migrations/2025_12_18_000000_add_interac_e_transfer_default_payment_method.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\Company;
+use App\Models\PaymentMethod;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Company::chunkById(100, function ($companies) {
+            foreach ($companies as $company) {
+                $exists = PaymentMethod::where('company_id', $company->id)
+                    ->whereRaw('LOWER(name) = ?', ['interac e-transfer'])
+                    ->exists();
+
+                if (! $exists) {
+                    PaymentMethod::create([
+                        'name' => 'Interac e-Transfer',
+                        'company_id' => $company->id,
+                    ]);
+                }
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        PaymentMethod::whereRaw('LOWER(name) = ?', ['interac e-transfer'])->delete();
+    }
+};

--- a/database/migrations/2025_12_18_000100_create_interac_e_transfer_logs_table.php
+++ b/database/migrations/2025_12_18_000100_create_interac_e_transfer_logs_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('interac_e_transfer_logs')) {
+            return;
+        }
+
+        Schema::create('interac_e_transfer_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('company_id');
+            $table->unsignedBigInteger('payment_id')->nullable();
+            $table->string('reference')->nullable();
+            $table->string('message_id')->nullable();
+            $table->string('sender_name')->nullable();
+            $table->string('sender_email')->nullable();
+            $table->unsignedBigInteger('amount')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+
+            $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
+            $table->foreign('payment_id')->references('id')->on('payments')->nullOnDelete();
+            $table->unique(['company_id', 'reference']);
+            $table->index(['company_id', 'message_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('interac_e_transfer_logs');
+    }
+};

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -18,6 +18,7 @@ FROM serversideup/php:8-fpm-alpine AS base
     RUN install-php-extensions bcmath
     RUN install-php-extensions intl
     RUN install-php-extensions curl
+    RUN install-php-extensions imap
 
 FROM base AS development
     ARG UID
@@ -26,4 +27,3 @@ FROM base AS development
     USER root
     RUN docker-php-serversideup-set-id www-data $UID:$GID
     USER www-data
-

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -18,6 +18,7 @@ FROM serversideup/php:8.3-fpm-nginx-alpine AS base
     RUN install-php-extensions bcmath
     RUN install-php-extensions intl
     RUN install-php-extensions curl
+    RUN install-php-extensions imap
 
 FROM base AS production
     ENV AUTORUN_ENABLED=true

--- a/lang/en.json
+++ b/lang/en.json
@@ -859,7 +859,8 @@
       "notes": "Notes",
       "exchange_rate": "Exchange Rate",
       "address_information": "Address Information",
-      "pdf_generation": "PDF Generation"
+      "pdf_generation": "PDF Generation",
+      "interac_e_transfer": "Interac e-Transfer"
     },
     "address_information": {
       "section_description": "  You can update Your Address information using form below."
@@ -908,6 +909,40 @@
       "from_mail": "From Mail Address",
       "encryption": "Mail Encryption",
       "mail_config_desc": "Below is the form for Configuring Email driver for sending emails from the app. You can also configure third party providers like Sendgrid, SES etc."
+    },
+    "interac": {
+      "title": "Interac e-Transfer",
+      "description": "Connect an IMAP mailbox to automatically create payments from Interac e-Transfer emails.",
+      "enable_sync": "Enable automatic payments",
+      "sender_filter": "Sender filter",
+      "sender_filter_help": "Only process emails from this address (e.g. notify(at)payments.interac.ca). Leave blank to process all unseen emails.",
+      "imap_host": "IMAP Host",
+      "imap_port": "IMAP Port",
+      "imap_encryption": "Encryption",
+      "imap_username": "IMAP Username",
+      "imap_password": "IMAP Password",
+      "imap_folder": "Folder to watch",
+      "mark_as_read": "Mark as read after processing",
+      "mark_as_read_desc": "Leave off if you want to keep messages unread in your mailbox.",
+      "move_to_folder": "Move processed emails to",
+      "move_to_folder_help": "Use {customer} to include the payer's name when creating the folder.",
+      "validate_cert": "Validate certificate",
+      "validate_cert_desc": "Disable only if your mail server uses a self-signed certificate.",
+      "sync_now": "Sync now",
+      "save_success": "Interac settings saved successfully",
+      "sync_success": "Mailbox checked. {messages} messages seen, {created} payments created.",
+      "last_sync": "Last sync: status {status}, {messages} messages checked, {created} payments created.",
+      "connection_status": "Connection status: {status}",
+      "connection_status_toast": "Mailbox connection test: {status}",
+      "connection_status_states": {
+        "ok": "Connected",
+        "disabled": "Disabled",
+        "connection_failed": "Connection failed",
+        "missing_extension": "PHP IMAP extension missing"
+      },
+      "encryption_none": "None",
+      "encryption_ssl": "SSL",
+      "encryption_tls": "STARTTLS/TLS"
     },
     "pdf": {
       "title": "PDF Setting",

--- a/resources/scripts/admin/admin-router.js
+++ b/resources/scripts/admin/admin-router.js
@@ -58,6 +58,8 @@ const RolesSettings = () =>
   import('@/scripts/admin/views/settings/RolesSettings.vue')
 const PDFGenerationSettings = () =>
   import('@/scripts/admin/views/settings/PDFGenerationSetting.vue')
+const InteracETransferSettings = () =>
+  import('@/scripts/admin/views/settings/InteracETransferSetting.vue')
 
 // Items
 const ItemsIndex = () => import('@/scripts/admin/views/items/Index.vue')
@@ -291,6 +293,12 @@ export default [
             path: 'payment-mode',
             name: 'payment.mode',
             component: PaymentMode,
+          },
+          {
+            path: 'interac-e-transfer',
+            name: 'settings.interac',
+            meta: { isOwner: true, ability: abilities.CREATE_PAYMENT },
+            component: InteracETransferSettings,
           },
           {
             path: 'custom-fields',

--- a/resources/scripts/admin/views/settings/InteracETransferSetting.vue
+++ b/resources/scripts/admin/views/settings/InteracETransferSetting.vue
@@ -1,0 +1,325 @@
+<template>
+  <BaseSettingCard
+    :title="$t('settings.interac.title')"
+    :description="$t('settings.interac.description')"
+  >
+    <template #action>
+      <BaseButton
+        variant="primary-outline"
+        :disabled="!canSync || isSyncing || isSaving"
+        :loading="isSyncing"
+        type="button"
+        @click="syncMailbox"
+      >
+        <template #left="slotProps">
+          <BaseIcon :class="slotProps.class" name="ArrowPathIcon" />
+        </template>
+        {{ $t('settings.interac.sync_now') }}
+      </BaseButton>
+    </template>
+
+    <form class="mt-10" @submit.prevent="saveSettings">
+      <ul class="divide-y divide-gray-200">
+        <BaseSwitchSection
+          v-model="form.enabled"
+          :title="$t('settings.interac.enable_sync')"
+          :description="$t('settings.interac.description')"
+        />
+      </ul>
+
+      <BaseInputGrid class="mt-6">
+        <BaseInputGroup :label="$t('settings.interac.sender_filter')">
+          <BaseInput
+            v-model.trim="form.sender_filter"
+            :content-loading="isLoading"
+            :placeholder="$t('settings.interac.sender_filter_help')"
+          />
+        </BaseInputGroup>
+
+        <BaseInputGroup :label="$t('settings.interac.imap_host')" required>
+          <BaseInput
+            v-model.trim="form.host"
+            :content-loading="isLoading"
+            required
+          />
+        </BaseInputGroup>
+
+        <BaseInputGroup :label="$t('settings.interac.imap_port')" required>
+          <BaseInput
+            v-model.number="form.port"
+            type="number"
+            min="1"
+            :content-loading="isLoading"
+            required
+          />
+        </BaseInputGroup>
+
+        <BaseInputGroup :label="$t('settings.interac.imap_encryption')" required>
+          <BaseMultiselect
+            v-model="form.encryption"
+            :content-loading="isLoading"
+            :options="encryptionOptions"
+            value-prop="value"
+            label="label"
+            :can-clear="false"
+          />
+        </BaseInputGroup>
+
+        <BaseInputGroup :label="$t('settings.interac.imap_username')" required>
+          <BaseInput
+            v-model.trim="form.username"
+            :content-loading="isLoading"
+            autocomplete="username"
+            required
+          />
+        </BaseInputGroup>
+
+        <BaseInputGroup :label="$t('settings.interac.imap_password')" required>
+          <BaseInput
+            v-model="form.password"
+            :content-loading="isLoading"
+            type="password"
+            autocomplete="current-password"
+            required
+          />
+        </BaseInputGroup>
+
+        <BaseInputGroup :label="$t('settings.interac.imap_folder')" required>
+          <BaseInput
+            v-model.trim="form.folder"
+            :content-loading="isLoading"
+            required
+          />
+        </BaseInputGroup>
+
+        <BaseInputGroup :label="$t('settings.interac.move_to_folder')">
+          <BaseInput
+            v-model.trim="form.move_to"
+            :content-loading="isLoading"
+            :placeholder="$t('settings.interac.move_to_folder_help')"
+          />
+          <p class="mt-1 text-xs text-gray-500">
+            {{ $t('settings.interac.move_to_folder_help') }}
+          </p>
+        </BaseInputGroup>
+      </BaseInputGrid>
+
+      <ul class="divide-y divide-gray-200 mt-6">
+        <BaseSwitchSection
+          v-model="form.mark_as_read"
+          :title="$t('settings.interac.mark_as_read')"
+          :description="$t('settings.interac.mark_as_read_desc')"
+        />
+        <BaseSwitchSection
+          v-model="form.validate_cert"
+          :title="$t('settings.interac.validate_cert')"
+          :description="$t('settings.interac.validate_cert_desc')"
+        />
+      </ul>
+
+      <div v-if="lastSyncResult" class="mt-4 text-sm text-gray-600">
+        {{ $t('settings.interac.last_sync', {
+          status: lastSyncResult.status,
+          messages: lastSyncResult.messages_checked ?? 0,
+          created: lastSyncResult.payments_created ?? 0,
+        }) }}
+      </div>
+
+      <div v-if="connectionStatus" class="mt-4 text-sm text-gray-600">
+        {{ $t('settings.interac.connection_status', { status: connectionStatus.status }) }}
+      </div>
+
+      <div class="flex justify-end gap-3 mt-8">
+        <BaseButton
+          type="submit"
+          variant="primary"
+          :loading="isSaving"
+          :disabled="isSaving"
+        >
+          <template #left="slotProps">
+            <BaseIcon :class="slotProps.class" name="ArrowDownOnSquareIcon" />
+          </template>
+          {{ $t('general.save') }}
+        </BaseButton>
+      </div>
+    </form>
+  </BaseSettingCard>
+</template>
+
+<script setup>
+import axios from 'axios'
+import { computed, onMounted, reactive, ref } from 'vue'
+import { useCompanyStore } from '@/scripts/admin/stores/company'
+import { useNotificationStore } from '@/scripts/stores/notification'
+import { handleError } from '@/scripts/helpers/error-handling'
+import { useI18n } from 'vue-i18n'
+
+const companyStore = useCompanyStore()
+const notificationStore = useNotificationStore()
+const { t } = useI18n()
+
+const isLoading = ref(false)
+const isSaving = ref(false)
+const isSyncing = ref(false)
+const lastSyncResult = ref(null)
+const connectionStatus = ref(null)
+
+const form = reactive({
+  enabled: false,
+  sender_filter: 'notify@payments.interac.ca',
+  host: '',
+  port: 993,
+  encryption: 'ssl',
+  username: '',
+  password: '',
+  folder: 'INBOX',
+  mark_as_read: true,
+  move_to: '',
+  validate_cert: true,
+})
+
+const encryptionOptions = computed(() => [
+  { label: t('settings.interac.encryption_ssl'), value: 'ssl' },
+  { label: t('settings.interac.encryption_tls'), value: 'tls' },
+  { label: t('settings.interac.encryption_none'), value: 'none' },
+])
+
+const canSync = computed(() => {
+  return (
+    form.enabled &&
+    form.host &&
+    form.port &&
+    form.username &&
+    form.password &&
+    form.folder
+  )
+})
+
+const settingKeys = [
+  'interac_enabled',
+  'interac_sender_filter',
+  'interac_imap_host',
+  'interac_imap_port',
+  'interac_imap_encryption',
+  'interac_imap_username',
+  'interac_imap_password',
+  'interac_imap_folder',
+  'interac_imap_mark_as_read',
+  'interac_imap_move_to',
+  'interac_imap_validate_cert',
+]
+
+onMounted(loadSettings)
+
+async function loadSettings() {
+  try {
+    isLoading.value = true
+    const { data } = await companyStore.fetchCompanySettings(settingKeys)
+    hydrateForm(data)
+    connectionStatus.value = null
+  } catch (error) {
+    handleError(error)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function hydrateForm(settings) {
+  form.enabled = toBool(settings.interac_enabled, form.enabled)
+  form.sender_filter = settings.interac_sender_filter || form.sender_filter
+  form.host = settings.interac_imap_host || ''
+  form.port = settings.interac_imap_port
+    ? parseInt(settings.interac_imap_port)
+    : form.port
+  form.encryption = settings.interac_imap_encryption || form.encryption
+  form.username = settings.interac_imap_username || ''
+  form.password = settings.interac_imap_password || ''
+  form.folder = settings.interac_imap_folder || form.folder
+  form.mark_as_read = toBool(settings.interac_imap_mark_as_read, form.mark_as_read)
+  form.move_to = settings.interac_imap_move_to || ''
+  form.validate_cert = toBool(
+    settings.interac_imap_validate_cert,
+    form.validate_cert
+  )
+}
+
+function toBool(value, fallback = false) {
+  if (value === undefined || value === null) return fallback
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') return value === 1
+  return ['true', '1', 'yes', 'on', 'y', 't'].includes(
+    String(value).toLowerCase()
+  )
+}
+
+async function saveSettings() {
+  const payload = {
+    interac_enabled: form.enabled,
+    interac_sender_filter: form.sender_filter,
+    interac_imap_host: form.host,
+    interac_imap_port: form.port,
+    interac_imap_encryption: form.encryption,
+    interac_imap_username: form.username,
+    interac_imap_password: form.password,
+    interac_imap_folder: form.folder,
+    interac_imap_mark_as_read: form.mark_as_read,
+    interac_imap_move_to: form.move_to,
+    interac_imap_validate_cert: form.validate_cert,
+  }
+
+  try {
+    isSaving.value = true
+    const { data } = await companyStore.updateCompanySettings({
+      data: { settings: payload },
+      message: 'settings.interac.save_success',
+    })
+
+    if (data?.connection_status) {
+      connectionStatus.value = data.connection_status
+      const statusLabel = connectionStatusLabel(data.connection_status.status)
+      notificationStore.showNotification({
+        type: data.connection_status.status === 'ok' ? 'success' : 'warning',
+        message: t('settings.interac.connection_status_toast', {
+          status: statusLabel,
+        }),
+      })
+    }
+  } catch (error) {
+    handleError(error)
+  } finally {
+    isSaving.value = false
+  }
+}
+
+async function syncMailbox() {
+  try {
+    isSyncing.value = true
+    const { data } = await axios.post('/api/v1/payments/interac/sync')
+    lastSyncResult.value = data?.data
+
+    const messages = data?.data?.messages_checked ?? 0
+    const created = data?.data?.payments_created ?? 0
+    const status = data?.data?.status ?? 'ok'
+
+    notificationStore.showNotification({
+      type: status === 'ok' ? 'success' : 'warning',
+      message: t('settings.interac.sync_success', { messages, created }),
+    })
+  } catch (error) {
+    handleError(error)
+  } finally {
+    isSyncing.value = false
+  }
+}
+
+function connectionStatusLabel(status) {
+  const map = {
+    ok: t('settings.interac.connection_status_states.ok'),
+    disabled: t('settings.interac.connection_status_states.disabled'),
+    connection_failed: t('settings.interac.connection_status_states.connection_failed'),
+    missing_extension: t('settings.interac.connection_status_states.missing_extension'),
+  }
+
+  return map[status] || status
+}
+</script>

--- a/routes/api.php
+++ b/routes/api.php
@@ -64,6 +64,7 @@ use App\Http\Controllers\V1\Admin\Payment\PaymentMethodsController;
 use App\Http\Controllers\V1\Admin\Payment\PaymentsController;
 use App\Http\Controllers\V1\Admin\Payment\SendPaymentController;
 use App\Http\Controllers\V1\Admin\Payment\SendPaymentPreviewController;
+use App\Http\Controllers\V1\Admin\Payment\SyncInteracETransferController;
 use App\Http\Controllers\V1\Admin\RecurringInvoice\RecurringInvoiceController;
 use App\Http\Controllers\V1\Admin\RecurringInvoice\RecurringInvoiceFrequencyController;
 use App\Http\Controllers\V1\Admin\Role\AbilitiesController;
@@ -324,6 +325,8 @@ Route::prefix('/v1')->group(function () {
             Route::post('/payments/{payment}/send', SendPaymentController::class);
 
             Route::post('/payments/delete', [PaymentsController::class, 'delete']);
+
+            Route::post('/payments/interac/sync', SyncInteracETransferController::class);
 
             Route::apiResource('payments', PaymentsController::class);
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -20,6 +20,11 @@ if (InstallUtils::isDbCreated()) {
     Schedule::command('check:estimates:status')
         ->daily();
 
+    Schedule::command('interac:sync')
+        ->everyFiveMinutes()
+        ->runInBackground()
+        ->withoutOverlapping();
+
     $recurringInvoices = RecurringInvoice::where('status', 'ACTIVE')->get();
     foreach ($recurringInvoices as $recurringInvoice) {
         $timeZone = CompanySetting::getSetting('time_zone', $recurringInvoice->company_id);


### PR DESCRIPTION
- Add Interac IMAP sync service, log model, migrations, and scheduled interac:sync command to create payments from e‑Transfer emails.
- Expose a manual sync endpoint/controller and admin UI settings page for IMAP creds, sender filter, and sync/test actions with connection status feedback.
- Default-interac payment method seeded via migration; company settings handling tweaked to avoid null values; translations updated.
- PHP containers include IMAP extension to support mailbox connectivity.