### PR TITLE
Lock php version to 8.4 in Dockerfile

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM node AS static_builder
     COPY . /var/www/html
     RUN yarn && yarn build
 
-FROM serversideup/php:8-fpm-alpine AS base
+FROM serversideup/php:8.4-fpm-alpine AS base
     USER root
     RUN apk add --no-cache sqlite
     RUN install-php-extensions exif


### PR DESCRIPTION
Fixes #518 

The Dockerfile was updated to explicitly lock the PHP version to 8.4 to resolve compatibility issues with PHP 8.5 in the development environment