### PR TITLE
Add original invoice amount to payment PDF

### DIFF
--- a/resources/views/app/pdf/payment/payment.blade.php
+++ b/resources/views/app/pdf/payment/payment.blade.php
@@ -343,6 +343,10 @@
                             <td class="attribute-label">@lang('pdf_invoice_label')</td>
                             <td class="attribute-value"> &nbsp;{{ $payment->invoice->invoice_number }}</td>
                         </tr>
+                        <tr>
+                            <td class="attribute-label">Original Invoice Amount</td>
+                            <td class="attribute-value"> &nbsp;{!! format_money_pdf($payment->invoice->total, $payment->invoice->currency) !!}</td>
+                        </tr>
                     @endif
                 </table>
             </div>


### PR DESCRIPTION
Adds original invoice amount to right table data in PDF if Invoice is selected.

completes a portion of feature requested here: https://github.com/InvoiceShelf/InvoiceShelf/issues/558