### PR TITLE
Add formattedDueAmount attribute to Invoice model

### DIFF
--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -57,6 +57,7 @@ class Invoice extends Model implements HasMedia
         'formattedCreatedAt',
         'formattedInvoiceDate',
         'formattedDueDate',
+        'formattedDueAmount',
         'invoicePdfUrl',
     ];
 
@@ -190,6 +191,17 @@ class Invoice extends Model implements HasMedia
         return Carbon::parse($this->due_date)->translatedFormat($dateFormat);
     }
 
+    public function getFormattedDueAmountAttribute($value)
+    {
+        $currency = $this->currency;
+
+        if (! $currency) {
+            $currency = Currency::findOrFail(CompanySetting::getSetting('currency', $this->company_id));
+        }
+
+        return format_money_pdf($this->due_amount, $currency);
+    }
+    
     public function getFormattedInvoiceDateAttribute($value)
     {
         $dateFormat = CompanySetting::getSetting('carbon_date_format', $this->company_id);


### PR DESCRIPTION
Added a new function for formatted invoice "due amount" in Invoice model. This will allow display of Invoice "Balance Due" when payment.blade.php generates a payment receipt PDF. Proposed changes to payment.blade.php will go along with this change.

completes a portion of feature requested here: https://github.com/InvoiceShelf/InvoiceShelf/issues/558