### PR TITLE
Enhance payment PDF with invoice details - Invoice Balance Due and Status

### DIFF
--- a/resources/views/app/pdf/payment/payment.blade.php
+++ b/resources/views/app/pdf/payment/payment.blade.php
@@ -351,7 +351,13 @@
     </div>
     <div class="total-display-box">
         <p class="total-display-label">@lang('pdf_payment_amount_received_label')</p>
-        <span class="amount">{!! format_money_pdf($payment->amount, $payment->customer->currency) !!}</span>
+        <span class="amount">{!! format_money_pdf($payment->amount, $payment->customer->currency) !!}</span><br>
+        @if ($payment->invoice)
+            <p class="total-display-label">Balance Due</p>
+            <span class="amount">{!! $payment->invoice->formattedDueAmount !!}</span><br>
+            <p class="total-display-label">Invoice Status</p>
+            <span class="amount">{{ $payment->invoice->paid_status ?? $payment->invoice->status }}</span>
+        @endif
     </div>
     <div class="notes">
         @if ($notes)


### PR DESCRIPTION
Added invoice details including balance due and status to the payment PDF. This change relies on changes made to Invoice.php

requires pull request https://github.com/InvoiceShelf/InvoiceShelf/pull/569 to be merged first

completes a portion of feature requested here: https://github.com/InvoiceShelf/InvoiceShelf/issues/558