### PR TITLE
Bug fix in Dropbox file disk creation. Applies disk path.

### DIFF
--- a/app/Providers/DropboxServiceProvider.php
+++ b/app/Providers/DropboxServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
 use League\Flysystem\Filesystem;
@@ -28,7 +29,11 @@ class DropboxServiceProvider extends ServiceProvider
                 $config['token']
             );
 
-            return new Filesystem(new DropboxAdapter($client));
+            $root = trim($config['root'] ?? '', '/');
+            $adapter = new DropboxAdapter($client, $root);
+            $flysystem = new Filesystem($adapter);
+
+            return new FilesystemAdapter($flysystem, $adapter, $config);
         });
     }
 }


### PR DESCRIPTION
PRE-REVIEW REQUEST CHECKLIST:

- [x] I have listed all changes in the Changes section.
- [x] I have listed all issues this PR addresses in the Issues section.
- [x] I have tested my changes.
- [x] I have considered backwards compatibility.

CHANGES:
Modified: app/Providers/DropboxServiceProvider.php

Wraps the Flysystem object in a FilesystemAdapter so Laravel can call methods like put() on it. Reads the root from the config and passes it to the DropboxAdapter, so the Dropbox Root folder field you fill in actually gets applied (without this, the root path was being ignored even if the disk saved successfully). Fixes both the hard crash (the put() error) and the silent bug where the root path setting was never used. 

ISSUES:
Fixes #378 