### PR TITLE
Fix: Set Slug when creating/updating first company

### DIFF
--- a/resources/scripts/admin/views/installation/Step7CompanyInfo.vue
+++ b/resources/scripts/admin/views/installation/Step7CompanyInfo.vue
@@ -164,6 +164,7 @@
 <script setup>
 import { ref, computed, onMounted, reactive } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { deburr } from 'lodash'
 import { required, maxLength, helpers } from '@vuelidate/validators'
 import { useVuelidate } from '@vuelidate/core'
 import { useGlobalStore } from '@/scripts/admin/stores/global'
@@ -180,6 +181,7 @@ let logoFileName = ref(null)
 
 const companyForm = reactive({
   name: null,
+  slug: null,
   tax_id: null,
   vat_id: null,
   address: {
@@ -251,6 +253,18 @@ async function next() {
   }
 
   isSaving.value = true
+  
+  // Generate slug from company name (imitate Laravel's Str::slug)
+  if (companyForm.name) {
+    companyForm.slug = deburr(companyForm.name)    // Remove accents etc.
+      .toLowerCase()
+      .trim()
+      .replace(/_/g, '-')                           
+      .replace(/[^a-z0-9\s-]/g, '')                  // Remove all non-alphanumeric chars
+      .replace(/[\s-]+/g, '-')
+      .replace(/^-+|-+$/g, '')                       // Trim dashes
+  }
+  
   let res = companyStore.updateCompany(companyForm)
   if (res) {
     if (logoFileBlob.value) {


### PR DESCRIPTION
When setting up the first company, the default slug xyz is never updated which causes this slug to be displayed in the client area URL. This fix actually sets the slug when the company is initialised. 

I've considered using the slug function by Laravel which is normally used when creating additional companies but it would require implementing this in the general Company Update handler which seems too complicated (because the slug could be accidentally changed when other aspects of the company are updated). 