### PR TITLE
Fix PDF notes line breaks

### DIFF
--- a/app/Support/PdfHtmlSanitizer.php
+++ b/app/Support/PdfHtmlSanitizer.php
@@ -19,6 +19,9 @@ final class PdfHtmlSanitizer
             return '';
         }
 
+        // Legacy/invalid `</br>` is dropped by libxml and collapses lines in PDF output; normalize to `<br />`.
+        $html = str_replace('</br>', '<br />', $html);
+
         $allowedTags = '<br><br/><p><b><strong><i><em><u><ol><ul><li><table><tr><td><th><thead><tbody><tfoot><h1><h2><h3><h4><blockquote>';
         $html = strip_tags($html, $allowedTags);
 

--- a/app/Traits/GeneratesPdfTrait.php
+++ b/app/Traits/GeneratesPdfTrait.php
@@ -180,7 +180,7 @@ trait GeneratesPdfTrait
 
         $str = str_replace('<p>', '', $str);
 
-        $str = str_replace('</p>', '</br>', $str);
+        $str = str_replace('</p>', '<br />', $str);
 
         return $str;
     }

--- a/resources/views/app/pdf/estimate/estimate1.blade.php
+++ b/resources/views/app/pdf/estimate/estimate1.blade.php
@@ -436,7 +436,7 @@
         </div>
 
         <div class="customer-address-container">
-            @if ($billing_address !== '</br>')
+            @if ($billing_address !== '<br />')
                 <div class="billing-address-container billing-address">
                     @if ($billing_address)
                         <b>@lang('pdf_bill_to')</b> <br>
@@ -446,7 +446,7 @@
             @endif
 
 
-            <div @if ($billing_address !== '</br>') class="shipping-address-container shipping-address" @else class="shipping-address-container--left shipping-address" style="padding-left:30px;" @endif>
+            <div @if ($billing_address !== '<br />') class="shipping-address-container shipping-address" @else class="shipping-address-container--left shipping-address" style="padding-left:30px;" @endif>
 
                 @if ($shipping_address)
                     <b>@lang('pdf_ship_to') </b> <br>

--- a/resources/views/app/pdf/estimate/estimate2.blade.php
+++ b/resources/views/app/pdf/estimate/estimate2.blade.php
@@ -444,7 +444,7 @@
                 {!! $company_address !!}
             </div>
 
-            @if ($shipping_address !== '</br>')
+            @if ($shipping_address !== '<br />')
                 <div class="shipping-address-container shipping-address">
                     @if ($shipping_address)
                         <b>@lang('pdf_ship_to')</b> <br>
@@ -453,7 +453,7 @@
                 </div>
             @endif
 
-            <div class="billing-address-container billing-address" @if ($shipping_address === '</br>') style="float:right; margin-right:30px;" @endif>
+            <div class="billing-address-container billing-address" @if ($shipping_address === '<br />') style="float:right; margin-right:30px;" @endif>
                 @if ($billing_address)
                     <b>@lang('pdf_bill_to')</b> <br>
                     {!! $billing_address !!}

--- a/resources/views/app/pdf/invoice/invoice1.blade.php
+++ b/resources/views/app/pdf/invoice/invoice1.blade.php
@@ -384,7 +384,7 @@
             @endif
         </div>
 
-        <div class="shipping-address-container shipping-address" @if ($billing_address !== '</br>') style="float:left;" @else style="display:block; float:left: padding-left: 0px;" @endif>
+        <div class="shipping-address-container shipping-address" @if ($billing_address !== '<br />') style="float:left;" @else style="display:block; float:left: padding-left: 0px;" @endif>
             @if ($shipping_address)
                 <b>@lang('pdf_ship_to')</b> <br>
 

--- a/resources/views/app/pdf/invoice/invoice2.blade.php
+++ b/resources/views/app/pdf/invoice/invoice2.blade.php
@@ -415,7 +415,7 @@
                 {!! $company_address !!}
             </div>
 
-            @if ($shipping_address !== '</br>')
+            @if ($shipping_address !== '<br />')
                 <div class="shipping-address-container shipping-address">
                     @if ($shipping_address)
                         <b>@lang('pdf_ship_to')</b> <br>
@@ -425,7 +425,7 @@
             @endif
 
 
-            <div class="billing-address-container billing-address" @if ($shipping_address === '</br>') style="float:right; margin-right:30px;" @endif>
+            <div class="billing-address-container billing-address" @if ($shipping_address === '<br />') style="float:right; margin-right:30px;" @endif>
                 @if ($billing_address)
                     <b>@lang('pdf_bill_to')</b> <br>
                     {!! $billing_address !!}

--- a/resources/views/app/pdf/invoice/invoice3.blade.php
+++ b/resources/views/app/pdf/invoice/invoice3.blade.php
@@ -343,7 +343,7 @@
                     @endif
                 </div>
 
-                <div @if ($billing_address !== '</br>') class="shipping-address-container shipping-address" @else class="shipping-address-container--left shipping-address" @endif>
+                <div @if ($billing_address !== '<br />') class="shipping-address-container shipping-address" @else class="shipping-address-container--left shipping-address" @endif>
                     @if ($shipping_address)
                         <b>@lang('pdf_ship_to')</b> <br>
                         {!! $shipping_address !!}

--- a/tests/Unit/PdfHtmlSanitizerTest.php
+++ b/tests/Unit/PdfHtmlSanitizerTest.php
@@ -25,3 +25,12 @@ it('strips style and link attributes that may carry URLs', function () {
 it('returns empty string for empty input', function () {
     expect(PdfHtmlSanitizer::sanitize(''))->toBe('');
 });
+
+it('normalizes legacy closing-br markup so lines are not collapsed in PDF output', function () {
+    $html = 'line1</br>line2';
+
+    $out = PdfHtmlSanitizer::sanitize($html);
+
+    expect($out)->toContain('<br')->toContain('line1')->toContain('line2');
+    expect($out)->not->toBe('line1line2');
+});


### PR DESCRIPTION
Fix collapsed multi-line notes on invoice PDFs by using valid `<br />` instead of `</br>`, which libxml was stripping.

Closes #588