### PR TITLE
Upgrade Pinia from v2 to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mini-svg-data-uri": "^1.4.4",
     "moment": "^2.30.1",
     "path": "^0.12.7",
-    "pinia": "^2.3.0",
+    "pinia": "^3.0.0",
     "v-money3": "^3.24.1",
     "v-tooltip": "^4.0.0-beta.17",
     "vite": "^8.0.0",

--- a/resources/scripts/admin/stores/auth.js
+++ b/resources/scripts/admin/stores/auth.js
@@ -7,8 +7,7 @@ export const useAuthStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'auth',
+  return defineStoreFunc('auth', {
     state: () => ({
       status: '',
 

--- a/resources/scripts/admin/stores/backup.js
+++ b/resources/scripts/admin/stores/backup.js
@@ -7,9 +7,7 @@ export const useBackupStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'backup',
-
+  return defineStoreFunc('backup', {
     state: () => ({
       backups: [],
       currentBackupData: {

--- a/resources/scripts/admin/stores/category.js
+++ b/resources/scripts/admin/stores/category.js
@@ -7,9 +7,7 @@ export const useCategoryStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'category',
-
+  return defineStoreFunc('category', {
     state: () => ({
       categories: [],
       currentCategory: {

--- a/resources/scripts/admin/stores/company.js
+++ b/resources/scripts/admin/stores/company.js
@@ -8,9 +8,7 @@ export const useCompanyStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'company',
-
+  return defineStoreFunc('company', {
     state: () => ({
       companies: [],
       selectedCompany: null,

--- a/resources/scripts/admin/stores/custom-field.js
+++ b/resources/scripts/admin/stores/custom-field.js
@@ -10,9 +10,7 @@ export const useCustomFieldStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'custom-field',
-
+  return defineStoreFunc('custom-field', {
     state: () => ({
       customFields: [],
       isRequestOngoing: false,

--- a/resources/scripts/admin/stores/customer.js
+++ b/resources/scripts/admin/stores/customer.js
@@ -12,8 +12,7 @@ export const useCustomerStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'customer',
+  return defineStoreFunc('customer', {
     state: () => ({
       customers: [],
       totalCustomers: 0,

--- a/resources/scripts/admin/stores/dashboard.js
+++ b/resources/scripts/admin/stores/dashboard.js
@@ -7,9 +7,7 @@ export const useDashboardStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'dashboard',
-
+  return defineStoreFunc('dashboard', {
     state: () => ({
       stats: {
         totalAmountDue: 0,

--- a/resources/scripts/admin/stores/disk.js
+++ b/resources/scripts/admin/stores/disk.js
@@ -7,9 +7,7 @@ export const useDiskStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'disk',
-
+  return defineStoreFunc('disk', {
     state: () => ({
       disks: [],
       diskDrivers: [],

--- a/resources/scripts/admin/stores/estimate.js
+++ b/resources/scripts/admin/stores/estimate.js
@@ -20,9 +20,7 @@ export const useEstimateStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'estimate',
-
+  return defineStoreFunc('estimate', {
     state: () => ({
       templates: [],
 

--- a/resources/scripts/admin/stores/exchange-rate.js
+++ b/resources/scripts/admin/stores/exchange-rate.js
@@ -8,9 +8,7 @@ export const useExchangeRateStore = (useWindow = false) => {
   const { global } = window.i18n
   const notificationStore = useNotificationStore()
 
-  return defineStoreFunc({
-    id: 'exchange-rate',
-
+  return defineStoreFunc('exchange-rate', {
     state: () => ({
       supportedCurrencies: [],
       drivers: [],

--- a/resources/scripts/admin/stores/expense.js
+++ b/resources/scripts/admin/stores/expense.js
@@ -9,9 +9,7 @@ export const useExpenseStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'expense',
-
+  return defineStoreFunc('expense', {
     state: () => ({
       expenses: [],
       totalExpenses: 0,

--- a/resources/scripts/admin/stores/global.js
+++ b/resources/scripts/admin/stores/global.js
@@ -11,8 +11,7 @@ export const useGlobalStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'global',
+  return defineStoreFunc('global', {
     state: () => ({
       // Global Configuration
       config: null,

--- a/resources/scripts/admin/stores/installation.js
+++ b/resources/scripts/admin/stores/installation.js
@@ -8,9 +8,7 @@ export const useInstallationStore = (useWindow = false) => {
   const { global } = window.i18n
   const companyStore = useCompanyStore()
 
-  return defineStoreFunc({
-    id: 'installation',
-
+  return defineStoreFunc('installation', {
     state: () => ({
       currentDataBaseData: {
         database_connection: 'mysql',

--- a/resources/scripts/admin/stores/invoice.js
+++ b/resources/scripts/admin/stores/invoice.js
@@ -22,8 +22,7 @@ export const useInvoiceStore = (useWindow = false) => {
   const { global } = window.i18n
   const notificationStore = useNotificationStore()
 
-  return defineStoreFunc({
-    id: 'invoice',
+  return defineStoreFunc('invoice', {
     state: () => ({
       templates: [],
       invoices: [],

--- a/resources/scripts/admin/stores/item.js
+++ b/resources/scripts/admin/stores/item.js
@@ -7,8 +7,7 @@ export const useItemStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'item',
+  return defineStoreFunc('item', {
     state: () => ({
       items: [],
       totalItems: 0,

--- a/resources/scripts/admin/stores/mail-driver.js
+++ b/resources/scripts/admin/stores/mail-driver.js
@@ -7,9 +7,7 @@ export const useMailDriverStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'mail-driver',
-
+  return defineStoreFunc('mail-driver', {
     state: () => ({
       mailConfigData: null,
       mail_driver: 'smtp',

--- a/resources/scripts/admin/stores/module.js
+++ b/resources/scripts/admin/stores/module.js
@@ -7,9 +7,7 @@ export const useModuleStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'modules',
-
+  return defineStoreFunc('modules', {
     state: () => ({
       currentModule: {},
       modules: [],

--- a/resources/scripts/admin/stores/note.js
+++ b/resources/scripts/admin/stores/note.js
@@ -6,9 +6,7 @@ export const useNotesStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'notes',
-
+  return defineStoreFunc('notes', {
     state: () => ({
       notes: [],
       currentNote: {

--- a/resources/scripts/admin/stores/payment.js
+++ b/resources/scripts/admin/stores/payment.js
@@ -12,9 +12,7 @@ export const usePaymentStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'payment',
-
+  return defineStoreFunc('payment', {
     state: () => ({
       payments: [],
       paymentTotalCount: 0,

--- a/resources/scripts/admin/stores/pdf-driver.js
+++ b/resources/scripts/admin/stores/pdf-driver.js
@@ -7,9 +7,7 @@ export const usePDFDriverStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'pdf-driver',
-
+  return defineStoreFunc('pdf-driver', {
     state: () => ({
       pdfDriverConfig: null,
       pdf_driver: 'dompdf',

--- a/resources/scripts/admin/stores/recurring-invoice.js
+++ b/resources/scripts/admin/stores/recurring-invoice.js
@@ -20,9 +20,7 @@ export const useRecurringInvoiceStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'recurring-invoice',
-
+  return defineStoreFunc('recurring-invoice', {
     state: () => ({
       templates: [],
       recurringInvoices: [],

--- a/resources/scripts/admin/stores/reset.js
+++ b/resources/scripts/admin/stores/reset.js
@@ -29,8 +29,7 @@ export const useResetStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'reset',
+  return defineStoreFunc('reset', {
     actions: {
       clearPinia() {
         const backupStore = useBackupStore()

--- a/resources/scripts/admin/stores/role.js
+++ b/resources/scripts/admin/stores/role.js
@@ -8,8 +8,7 @@ export const useRoleStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'role',
+  return defineStoreFunc('role', {
     state: () => ({
       roles: [],
       allAbilities: [],

--- a/resources/scripts/admin/stores/tax-type.js
+++ b/resources/scripts/admin/stores/tax-type.js
@@ -7,9 +7,7 @@ export const useTaxTypeStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'taxType',
-
+  return defineStoreFunc('taxType', {
     state: () => ({
       taxTypes: [],
       currentTaxType: {

--- a/resources/scripts/admin/stores/user.js
+++ b/resources/scripts/admin/stores/user.js
@@ -7,9 +7,7 @@ export const useUserStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'user',
-
+  return defineStoreFunc('user', {
     state: () => ({
       currentUser: null,
       currentAbilities: [],

--- a/resources/scripts/admin/stores/users.js
+++ b/resources/scripts/admin/stores/users.js
@@ -7,8 +7,7 @@ export const useUsersStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'users',
+  return defineStoreFunc('users', {
     state: () => ({
       roles: [],
       users: [],

--- a/resources/scripts/customer/stores/auth.js
+++ b/resources/scripts/customer/stores/auth.js
@@ -5,8 +5,7 @@ import router from '@/scripts/customer/customer-router'
 import { handleError } from '@/scripts/customer/helpers/error-handling'
 const { global } = window.i18n
 
-export const useAuthStore = defineStore({
-  id: 'customerAuth',
+export const useAuthStore = defineStore('customerAuth', {
   state: () => ({
     loginData: {
       email: '',

--- a/resources/scripts/customer/stores/customer.js
+++ b/resources/scripts/customer/stores/customer.js
@@ -1,7 +1,6 @@
 const { defineStore } = window.pinia
 
-export const useCustomerStore = defineStore({
-  id: 'customers',
+export const useCustomerStore = defineStore('customers', {
   state: () => ({
     customers: 'okay',
   }),

--- a/resources/scripts/customer/stores/dashboard.js
+++ b/resources/scripts/customer/stores/dashboard.js
@@ -3,8 +3,7 @@ import { useGlobalStore } from '@/scripts/customer/stores/global'
 import http from '@/scripts/http'
 import { handleError } from '@/scripts/customer/helpers/error-handling'
 
-export const useDashboardStore = defineStore({
-  id: 'dashboard',
+export const useDashboardStore = defineStore('dashboard', {
   state: () => ({
     recentInvoices: [],
     recentEstimates: [],

--- a/resources/scripts/customer/stores/estimate.js
+++ b/resources/scripts/customer/stores/estimate.js
@@ -3,8 +3,7 @@ import { useNotificationStore } from '@/scripts/stores/notification'
 import http from '@/scripts/http'
 import { handleError } from '@/scripts/customer/helpers/error-handling'
 
-export const useEstimateStore = defineStore({
-  id: 'customerEstimateStore',
+export const useEstimateStore = defineStore('customerEstimateStore', {
   state: () => ({
     estimates: [],
     totalEstimates: 0,

--- a/resources/scripts/customer/stores/global.js
+++ b/resources/scripts/customer/stores/global.js
@@ -3,8 +3,7 @@ import { useUserStore } from './user'
 const { defineStore } = window.pinia
 import http from '@/scripts/http'
 const { global } = window.i18n
-export const useGlobalStore = defineStore({
-  id: 'CustomerPortalGlobalStore',
+export const useGlobalStore = defineStore('CustomerPortalGlobalStore', {
   state: () => ({
     languages: [],
     currency: null,

--- a/resources/scripts/customer/stores/invoice.js
+++ b/resources/scripts/customer/stores/invoice.js
@@ -1,8 +1,7 @@
 import { handleError } from '@/scripts/customer/helpers/error-handling'
 const { defineStore } = window.pinia
 import http from '@/scripts/http'
-export const useInvoiceStore = defineStore({
-  id: 'customerInvoiceStore',
+export const useInvoiceStore = defineStore('customerInvoiceStore', {
   state: () => ({
     totalInvoices: 0,
     invoices: [],

--- a/resources/scripts/customer/stores/payment.js
+++ b/resources/scripts/customer/stores/payment.js
@@ -2,8 +2,7 @@ import { handleError } from '@/scripts/customer/helpers/error-handling'
 const { defineStore } = window.pinia
 import http from '@/scripts/http'
 
-export const usePaymentStore = defineStore({
-  id: 'customerPaymentStore',
+export const usePaymentStore = defineStore('customerPaymentStore', {
   state: () => ({
     payments: [],
     selectedViewPayment: [],

--- a/resources/scripts/customer/stores/user.js
+++ b/resources/scripts/customer/stores/user.js
@@ -5,9 +5,7 @@ import stubs from '@/scripts/customer/stubs/address'
 import http from '@/scripts/http'
 import { useGlobalStore } from '@/scripts/customer/stores/global'
 
-export const useUserStore = defineStore({
-  id: 'customerUserStore',
-
+export const useUserStore = defineStore('customerUserStore', {
   state: () => ({
     customers: [],
     userForm: {

--- a/resources/scripts/stores/dialog.js
+++ b/resources/scripts/stores/dialog.js
@@ -4,8 +4,7 @@ export const useDialogStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'dialog',
+  return defineStoreFunc('dialog', {
     state: () => ({
       active: false,
       title: '',

--- a/resources/scripts/stores/modal.js
+++ b/resources/scripts/stores/modal.js
@@ -4,9 +4,7 @@ export const useModalStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
   const { global } = window.i18n
 
-  return defineStoreFunc({
-    id: 'modal',
-
+  return defineStoreFunc('modal', {
     state: () => ({
       active: false,
       content: '',

--- a/resources/scripts/stores/notification.js
+++ b/resources/scripts/stores/notification.js
@@ -3,9 +3,7 @@ import { defineStore } from 'pinia'
 export const useNotificationStore = (useWindow = false) => {
   const defineStoreFunc = useWindow ? window.pinia.defineStore : defineStore
 
-  return defineStoreFunc({
-    id: 'notification',
-
+  return defineStoreFunc('notification', {
     state: () => ({
       active: false,
       autoHide: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -583,10 +583,37 @@
     "@vue/compiler-dom" "3.5.13"
     "@vue/shared" "3.5.13"
 
-"@vue/devtools-api@^6.5.0", "@vue/devtools-api@^6.6.3", "@vue/devtools-api@^6.6.4":
+"@vue/devtools-api@^6.5.0", "@vue/devtools-api@^6.6.4":
   version "6.6.4"
   resolved "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz"
   integrity sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==
+
+"@vue/devtools-api@^7.7.7":
+  version "7.7.9"
+  resolved "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz"
+  integrity sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==
+  dependencies:
+    "@vue/devtools-kit" "^7.7.9"
+
+"@vue/devtools-kit@^7.7.9":
+  version "7.7.9"
+  resolved "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz"
+  integrity sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==
+  dependencies:
+    "@vue/devtools-shared" "^7.7.9"
+    birpc "^2.3.0"
+    hookable "^5.5.3"
+    mitt "^3.0.1"
+    perfect-debounce "^1.0.0"
+    speakingurl "^14.0.1"
+    superjson "^2.2.2"
+
+"@vue/devtools-shared@^7.7.9":
+  version "7.7.9"
+  resolved "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz"
+  integrity sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==
+  dependencies:
+    rfdc "^1.4.1"
 
 "@vue/reactivity@3.5.13":
   version "3.5.13"
@@ -721,6 +748,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+birpc@^2.3.0:
+  version "2.9.0"
+  resolved "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz"
+  integrity sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==
+
 boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
@@ -818,6 +850,13 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+copy-anything@^4:
+  version "4.0.5"
+  resolved "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz"
+  integrity sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==
+  dependencies:
+    is-what "^5.2.0"
 
 crelt@^1.0.0:
   version "1.0.6"
@@ -1225,6 +1264,11 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hookable@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz"
+  integrity sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==
+
 ignore@^5.2.0:
   version "5.3.2"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"
@@ -1259,6 +1303,11 @@ is-glob@^4.0.0, is-glob@^4.0.3:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-what@^5.2.0:
+  version "5.5.0"
+  resolved "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz"
+  integrity sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -1437,6 +1486,11 @@ minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+mitt@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz"
+  integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
+
 moment@^2.10.2, moment@^2.30.1:
   version "2.30.1"
   resolved "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz"
@@ -1520,6 +1574,11 @@ path@^0.12.7:
     process "^0.11.1"
     util "^0.10.3"
 
+perfect-debounce@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz"
+  integrity sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==
+
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
@@ -1540,13 +1599,12 @@ picomatch@^4.0.4:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
-pinia@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/pinia/-/pinia-2.3.0.tgz"
-  integrity sha512-ohZj3jla0LL0OH5PlLTDMzqKiVw2XARmC1XYLdLWIPBMdhDW/123ZWr4zVAhtJm+aoSkFa13pYXskAvAscIkhQ==
+pinia@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz"
+  integrity sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==
   dependencies:
-    "@vue/devtools-api" "^6.6.3"
-    vue-demi "^0.14.10"
+    "@vue/devtools-api" "^7.7.7"
 
 postcss-selector-parser@^6.0.15:
   version "6.1.2"
@@ -1775,6 +1833,11 @@ resolve-from@^4.0.0:
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
+rfdc@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz"
+  integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
+
 rolldown@1.0.0-rc.12:
   version "1.0.0-rc.12"
   resolved "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz"
@@ -1831,10 +1894,22 @@ source-map-js@^1.0.2, source-map-js@^1.2.0, source-map-js@^1.2.1:
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+speakingurl@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz"
+  integrity sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==
+
 strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+superjson@^2.2.2:
+  version "2.2.6"
+  resolved "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz"
+  integrity sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==
+  dependencies:
+    copy-anything "^4"
 
 supports-color@^7.1.0:
   version "7.2.0"
@@ -1960,11 +2035,6 @@ vue-demi@^0.13.11:
   resolved "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz"
   integrity sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==
 
-vue-demi@^0.14.10:
-  version "0.14.10"
-  resolved "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz"
-  integrity sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==
-
 vue-eslint-parser@^9.4.3:
   version "9.4.3"
   resolved "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.3.tgz"
@@ -2006,7 +2076,7 @@ vue-router@^4.5.0:
   dependencies:
     "@vue/devtools-api" "^6.6.4"
 
-"vue@^2.0.0 || >=3.0.0", "vue@^2.7.0 || ^3.0.0", "vue@^2.7.0 || ^3.5.11", vue@^3.0.0, "vue@^3.0.0-0 || ^2.6.0", vue@^3.0.1, vue@^3.0.11, vue@^3.2.0, vue@^3.2.25, vue@^3.5, vue@^3.5.13, "vue@>= 3", "vue@>= 3.2.0", vue@3.5.13:
+"vue@^2.0.0 || >=3.0.0", "vue@^2.7.0 || ^3.0.0", vue@^3.0.0, "vue@^3.0.0-0 || ^2.6.0", vue@^3.0.1, vue@^3.0.11, vue@^3.2.0, vue@^3.2.25, vue@^3.5, vue@^3.5.11, vue@^3.5.13, "vue@>= 3", "vue@>= 3.2.0", vue@3.5.13:
   version "3.5.13"
   resolved "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz"
   integrity sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==


### PR DESCRIPTION
## Pinia v3

Migrate all 37 store definitions from the deprecated object-with-id signature to the string-id-first signature required by Pinia 3.

- Update `pinia` dependency from `^2.3.0` to `^3.0.0`
- Migrate all 37 store definitions from the deprecated object-with-id signature to the new string-id-first signature:
  ```js
  // Before (Pinia 2)
  defineStore({ id: 'storeName', state: () => ({ ... }), ... })

  // After (Pinia 3)
  defineStore('storeName', { state: () => ({ ... }), ... })
  ```

### Stores updated

**Shared (3):** modal, dialog, notification

**Admin (29):** auth, user, users, global, company, customer, invoice, estimate, payment, expense, recurring-invoice, item, category, tax-type, note, role, dashboard, backup, disk, module, mail-driver, pdf-driver, exchange-rate, installation, custom-field, reset

**Customer portal (8):** auth, user, global, dashboard, invoice, estimate, payment, customer

### Breaking changes in Pinia 3

- The `defineStore({ id: '...' })` object signature is removed (migrated above)
- `PiniaStorePlugin` type renamed to `PiniaPlugin` (not applicable — no custom plugins used)
- Vue 2 support dropped (not applicable — project uses Vue 3)

## Test plan

- [x] App boots without console errors
- [x] Login/logout works (admin + customer portal)
- [x] Dashboard loads data correctly
- [x] CRUD flows: create, edit, delete an invoice, estimate, payment, expense
- [x] Settings pages load and save correctly
- [x] Customer portal: view invoices, estimates, payments
- [x] Module browsing works
- [x] `npm run build` passes
