### PR TITLE
Upgrade vue-router from v4 to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "vue": "^3.5",
     "vue-flatpickr-component": "^11.0.5",
     "vue-i18n": "^11.0.1",
-    "vue-router": "^4.5.0",
+    "vue-router": "^5.0.0",
     "vuedraggable": "^4.1.0"
   }
 }

--- a/resources/scripts/router/index.js
+++ b/resources/scripts/router/index.js
@@ -17,22 +17,20 @@ const router = createRouter({
   routes,
 })
 
-router.beforeEach((to, from, next) => {
+router.beforeEach((to) => {
   const userStore = useUserStore()
   const globalStore = useGlobalStore()
   let ability = to.meta.ability
   const { isAppLoaded } = globalStore
 
   if (ability && isAppLoaded && to.meta.requiresAuth) {
-    if (userStore.hasAbilities(ability)) {
-      next()
-    } else next({ name: 'account.settings' })
+    if (!userStore.hasAbilities(ability)) {
+      return { name: 'account.settings' }
+    }
   } else if (to.meta.isOwner && isAppLoaded) {
-    if (userStore.currentUser.is_owner) {
-      next()
-    } else next({ name: 'dashboard' })
-  } else {
-    next()
+    if (!userStore.currentUser.is_owner) {
+      return { name: 'dashboard' }
+    }
   }
 })
 


### PR DESCRIPTION
## Summary

Upgrade vue-router from v4 to v5.

- Update `vue-router` dependency from `^4.5.0` to `^5.0.0`
- Migrate `beforeEach` navigation guard from the deprecated `next()` callback API to the return-based API, preparing for vue-router v6 where `next()` is removed

### Navigation guard change

```js
// Before (v4 — next() callback)
router.beforeEach((to, from, next) => {
  if (authorized) next()
  else next({ name: 'login' })
})

// After (v5 — return-based)
router.beforeEach((to) => {
  if (!authorized) return { name: 'login' }
})
```

### Notes

- vue-router 5 is a transition release with no breaking changes for standard usage
- The `next()` callback still works in v5 (deprecated) but will be removed in v6

## Test plan

- [x] `npm run build` passes
- [x] Navigation between pages works
- [x] Unauthorized users are redirected to account settings
- [ ] Non-owner users cannot access owner-only routes
- [x] Direct URL navigation works correctly