### PR TITLE
Scope bulk deletes to company and fix inverted ownership transfer

### DIFF
--- a/app/Http/Controllers/V1/Admin/Company/CompaniesController.php
+++ b/app/Http/Controllers/V1/Admin/Company/CompaniesController.php
@@ -61,10 +61,10 @@ class CompaniesController extends Controller
         $company = Company::find($request->header('company'));
         $this->authorize('transfer company ownership', $company);
 
-        if ($user->hasCompany($company->id)) {
+        if (! $user->hasCompany($company->id)) {
             return response()->json([
                 'success' => false,
-                'message' => 'User does not belongs to this company.',
+                'message' => 'User does not belong to this company.',
             ]);
         }
 

--- a/app/Http/Controllers/V1/Admin/Estimate/EstimatesController.php
+++ b/app/Http/Controllers/V1/Admin/Estimate/EstimatesController.php
@@ -68,7 +68,11 @@ class EstimatesController extends Controller
     {
         $this->authorize('delete multiple estimates');
 
-        Estimate::destroy($request->ids);
+        $ids = Estimate::whereCompany()
+            ->whereIn('id', $request->ids)
+            ->pluck('id');
+
+        Estimate::destroy($ids);
 
         return response()->json([
             'success' => true,

--- a/app/Http/Controllers/V1/Admin/Expense/ExpensesController.php
+++ b/app/Http/Controllers/V1/Admin/Expense/ExpensesController.php
@@ -81,7 +81,11 @@ class ExpensesController extends Controller
     {
         $this->authorize('delete multiple expenses');
 
-        Expense::destroy($request->ids);
+        $ids = Expense::whereCompany()
+            ->whereIn('id', $request->ids)
+            ->pluck('id');
+
+        Expense::destroy($ids);
 
         return response()->json([
             'success' => true,

--- a/app/Http/Controllers/V1/Admin/Invoice/InvoicesController.php
+++ b/app/Http/Controllers/V1/Admin/Invoice/InvoicesController.php
@@ -100,7 +100,11 @@ class InvoicesController extends Controller
     {
         $this->authorize('delete multiple invoices');
 
-        Invoice::deleteInvoices($request->ids);
+        $ids = Invoice::whereCompany()
+            ->whereIn('id', $request->ids)
+            ->pluck('id');
+
+        Invoice::deleteInvoices($ids);
 
         return response()->json([
             'success' => true,

--- a/app/Http/Controllers/V1/Admin/Item/ItemsController.php
+++ b/app/Http/Controllers/V1/Admin/Item/ItemsController.php
@@ -90,7 +90,11 @@ class ItemsController extends Controller
     {
         $this->authorize('delete multiple items');
 
-        Item::destroy($request->ids);
+        $ids = Item::whereCompany()
+            ->whereIn('id', $request->ids)
+            ->pluck('id');
+
+        Item::destroy($ids);
 
         return response()->json([
             'success' => true,

--- a/app/Http/Controllers/V1/Admin/Payment/PaymentsController.php
+++ b/app/Http/Controllers/V1/Admin/Payment/PaymentsController.php
@@ -73,7 +73,11 @@ class PaymentsController extends Controller
     {
         $this->authorize('delete multiple payments');
 
-        Payment::deletePayments($request->ids);
+        $ids = Payment::whereCompany()
+            ->whereIn('id', $request->ids)
+            ->pluck('id');
+
+        Payment::deletePayments($ids);
 
         return response()->json([
             'success' => true,

--- a/app/Http/Controllers/V1/Admin/RecurringInvoice/RecurringInvoiceController.php
+++ b/app/Http/Controllers/V1/Admin/RecurringInvoice/RecurringInvoiceController.php
@@ -84,7 +84,11 @@ class RecurringInvoiceController extends Controller
     {
         $this->authorize('delete multiple recurring invoices');
 
-        RecurringInvoice::deleteRecurringInvoice($request->ids);
+        $ids = RecurringInvoice::whereCompany()
+            ->whereIn('id', $request->ids)
+            ->pluck('id');
+
+        RecurringInvoice::deleteRecurringInvoice($ids);
 
         return response()->json([
             'success' => true,


### PR DESCRIPTION
## Summary
Fixes remaining cross-company IDOR vulnerabilities from #567 (Finding 2 & 3). Finding 1 was fixed in #604.

### Cross-company bulk delete (6 controllers)
Scope IDs through `whereCompany()->whereIn('id', $ids)` before deleting:
- `InvoicesController` — `Invoice::deleteInvoices()` used `self::find($id)` without company scope
- `PaymentsController` — `Payment::deletePayments()` same issue
- `ItemsController` — `Item::destroy()` directly, no company scope
- `ExpensesController` — `Expense::destroy()` directly, no company scope
- `EstimatesController` — `Estimate::destroy()` directly, no company scope
- `RecurringInvoiceController` — `RecurringInvoice::deleteRecurringInvoice()` same issue

### Transfer ownership inverted logic
`CompaniesController::transferOwnership()` had an inverted `hasCompany()` check — it blocked transfer when the user DOES belong to the company, and allowed it when they DON'T. Fixed to `if (! $user->hasCompany(...))`.

## Test plan
- [x] All 263 tests pass
- [x] Customer cross-company tests from #604 continue to pass

Ref #567