### PR TITLE
Add company ownership check to clone endpoints

### DIFF
--- a/app/Http/Controllers/V1/Admin/Estimate/CloneEstimateController.php
+++ b/app/Http/Controllers/V1/Admin/Estimate/CloneEstimateController.php
@@ -21,6 +21,7 @@ class CloneEstimateController extends Controller
      */
     public function __invoke(Request $request, Estimate $estimate)
     {
+        $this->authorize('view', $estimate);
         $this->authorize('create', Estimate::class);
 
         $date = Carbon::now();

--- a/app/Http/Controllers/V1/Admin/Invoice/CloneInvoiceController.php
+++ b/app/Http/Controllers/V1/Admin/Invoice/CloneInvoiceController.php
@@ -21,6 +21,7 @@ class CloneInvoiceController extends Controller
      */
     public function __invoke(Request $request, Invoice $invoice)
     {
+        $this->authorize('view', $invoice);
         $this->authorize('create', Invoice::class);
 
         $date = Carbon::now();


### PR DESCRIPTION
## Summary
Add `$this->authorize('view', $record)` to clone controllers before cloning. The `view` policy includes `hasCompany()`, preventing cross-company data leaks.

- `CloneInvoiceController` — now checks `view` on source invoice before cloning
- `CloneEstimateController` — now checks `view` on source estimate before cloning

Previously, a user could clone invoices/estimates from other companies by providing the target ID, leaking amounts, customer details, items, taxes, and notes.

## Test plan
- [x] All 263 tests pass

Ref #574