### PR TITLE
Scope users listing and search to current company

### DIFF
--- a/app/Http/Controllers/V1/Admin/General/SearchController.php
+++ b/app/Http/Controllers/V1/Admin/General/SearchController.php
@@ -25,7 +25,8 @@ class SearchController extends Controller
             ->paginate(10);
 
         if ($user->isOwner()) {
-            $users = User::applyFilters($request->only(['search']))
+            $users = User::whereCompany()
+                ->applyFilters($request->only(['search']))
                 ->latest()
                 ->paginate(10);
         }

--- a/app/Http/Controllers/V1/Admin/Users/UsersController.php
+++ b/app/Http/Controllers/V1/Admin/Users/UsersController.php
@@ -25,14 +25,15 @@ class UsersController extends Controller
 
         $user = $request->user();
 
-        $users = User::applyFilters($request->all())
+        $users = User::whereCompany()
+            ->applyFilters($request->all())
             ->where('id', '<>', $user->id)
             ->latest()
             ->paginate($limit);
 
         return UserResource::collection($users)
             ->additional(['meta' => [
-                'user_total_count' => User::count(),
+                'user_total_count' => User::whereCompany()->count(),
             ]]);
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -213,6 +213,13 @@ class User extends Authenticatable implements HasMedia
         return $query->where('email', 'LIKE', '%'.$email.'%');
     }
 
+    public function scopeWhereCompany($query)
+    {
+        return $query->whereHas('companies', function ($q) {
+            $q->where('company_id', request()->header('company'));
+        });
+    }
+
     public function scopePaginateData($query, $limit)
     {
         if ($limit == 'all') {


### PR DESCRIPTION
## Summary
Users page was showing ALL users across all companies. Now scoped to current company.

- Add `scopeWhereCompany()` to User model — filters via `user_company` pivot table
- Apply `whereCompany()` in `UsersController::index()` query and total count
- Apply `whereCompany()` in `SearchController` user search

**Note:** The SuperAdmin `UsersController` (at `/api/v1/super-admin/users`) is intentionally NOT scoped — it needs to show all users across tenants.

## Test plan
- [x] All 263 tests pass
- [x] Manual: load company A → users page shows only company A members
- [x] Manual: load company B → users page shows only company B members

Ref #574