### PR TITLE
fix(migrations): align FK column types with users/companies id on MySQL

### DIFF
--- a/database/migrations/2026_04_03_070131_create_impersonation_logs_table.php
+++ b/database/migrations/2026_04_03_070131_create_impersonation_logs_table.php
@@ -10,8 +10,8 @@ return new class extends Migration
     {
         Schema::create('impersonation_logs', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('admin_id');
-            $table->unsignedBigInteger('user_id');
+            $table->unsignedInteger('admin_id');
+            $table->unsignedInteger('user_id');
             $table->string('ip_address', 45)->nullable();
             $table->unsignedBigInteger('token_id')->nullable();
             $table->timestamp('stopped_at')->nullable();

--- a/database/migrations/2026_04_03_204854_create_company_invitations_table.php
+++ b/database/migrations/2026_04_03_204854_create_company_invitations_table.php
@@ -10,13 +10,16 @@ return new class extends Migration
     {
         Schema::create('company_invitations', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('company_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->unsignedInteger('company_id');
+            $table->foreign('company_id')->references('id')->on('companies')->cascadeOnDelete();
+            $table->unsignedInteger('user_id')->nullable();
+            $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
             $table->string('email');
             $table->foreignId('role_id')->constrained('roles')->cascadeOnDelete();
             $table->string('token')->unique();
             $table->enum('status', ['pending', 'accepted', 'declined', 'expired'])->default('pending');
-            $table->foreignId('invited_by')->constrained('users')->cascadeOnDelete();
+            $table->unsignedInteger('invited_by');
+            $table->foreign('invited_by')->references('id')->on('users')->cascadeOnDelete();
             $table->timestamp('expires_at');
             $table->timestamps();
 


### PR DESCRIPTION
Laravel foreignId() creates BIGINT UNSIGNED columns, but users.id and companies.id use increments() (INT UNSIGNED). MySQL 8 rejects foreign keys when referencing and referenced column types differ (error 3780).

Use unsignedInteger for impersonation_logs admin_id/user_id and for company_invitations company_id, user_id, and invited_by. Keep foreignId for role_id since roles.id is bigIncrements.

This fixes upgrades from v2 on MySQL when running v3.0 migrations.