### PR TITLE
fix: localize country names in PDF invoices

### DIFF
--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -18,9 +18,18 @@ class Address extends Model
 
     public function getCountryNameAttribute()
     {
-        $name = $this->country ? $this->country->name : null;
+        if (! $this->country) {
+            return null;
+        }
 
-        return $name;
+        try {
+            return \Symfony\Component\Intl\Countries::getName(
+                $this->country->code,
+                app()->getLocale()
+            );
+        } catch (\Exception $e) {
+            return $this->country->name;
+        }
     }
 
     public function user(): BelongsTo

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "spatie/flysystem-dropbox": "^3.0",
         "spatie/laravel-backup": "^10.0",
         "spatie/laravel-medialibrary": "^11.11",
+        "symfony/intl": "^7.3",
         "symfony/mailer": "^7.3",
         "symfony/mailgun-mailer": "^7.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5df4a89701d63326d9f5d6a14d846659",
+    "content-hash": "def5db37a82c7902f271db604d5eea60",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6447,6 +6447,96 @@
                 }
             ],
             "time": "2026-03-06T16:58:46+00:00"
+        },
+        {
+            "name": "symfony/intl",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/intl.git",
+                "reference": "7cfb7792d580dea833647420afd5f2f98df8457b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/7cfb7792d580dea833647420afd5f2f98df8457b",
+                "reference": "7cfb7792d580dea833647420afd5f2f98df8457b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/string": "<7.1"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.4|^7.0|^8.0",
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Intl\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/",
+                    "/Resources/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Eriksen Costa",
+                    "email": "eriksen.costa@infranology.com.br"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides access to the localization data of the ICU library",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "i18n",
+                "icu",
+                "internationalization",
+                "intl",
+                "l10n",
+                "localization"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/intl/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T12:55:43+00:00"
         },
         {
             "name": "symfony/mailer",

--- a/tests/Unit/AddressCountryLocalizationTest.php
+++ b/tests/Unit/AddressCountryLocalizationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Models\Address;
+use App\Models\Company;
+use App\Models\Country;
+use App\Models\Customer;
+use App\Models\User;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Artisan;
+
+beforeEach(function () {
+    Artisan::call('db:seed', ['--class' => 'DatabaseSeeder', '--force' => true]);
+    Artisan::call('db:seed', ['--class' => 'DemoSeeder', '--force' => true]);
+});
+
+it('returns localized country name for German locale', function () {
+    App::setLocale('de');
+
+    $address = Address::factory()->create([
+        'country_id' => Country::where('code', 'DE')->first()->id,
+    ]);
+
+    expect($address->country_name)->toBe('Deutschland');
+});
+
+it('returns localized country name for French locale', function () {
+    App::setLocale('fr');
+
+    $address = Address::factory()->create([
+        'country_id' => Country::where('code', 'DE')->first()->id,
+    ]);
+
+    expect($address->country_name)->toBe('Allemagne');
+});
+
+it('returns null when address has no country', function () {
+    $address = Address::factory()->create([
+        'country_id' => null,
+    ]);
+
+    expect($address->country_name)->toBeNull();
+});
+
+it('falls back to database name when intl lookup fails', function () {
+    App::setLocale('de');
+
+    // Create a country with a code that won't be found in ICU data
+    $country = new Country;
+    $country->timestamps = false;
+    $country->code = 'XX';
+    $country->name = 'Unknown Land';
+    $country->phonecode = 0;
+    $country->save();
+
+    $address = Address::factory()->create([
+        'country_id' => $country->id,
+    ]);
+
+    expect($address->country_name)->toBe('Unknown Land');
+});


### PR DESCRIPTION
## Problem

Country names in generated PDF invoices and estimates are always displayed in English, regardless of the company language setting. When a user sets their language to German, the invoice layout is nicely localized but country names like "Germany" remain in English, which looks inconsistent.

## Solution

Use `Symfony\Component\Intl\Countries` to translate country names based on the current app locale in `Address::getCountryNameAttribute()`. Since `GeneratesPdfTrait` already sets `App::setLocale()` to the company language before PDF generation, the translated names flow through automatically to the `{BILLING_COUNTRY}`, `{SHIPPING_COUNTRY}`, and `{COMPANY_COUNTRY}` template placeholders.

## Scope

This change **only affects PDF/estimate generation**. The API responses (country dropdowns, address displays in the frontend) continue to return English names from the database for now.