### PR TITLE
.1502411993651747:b9e98f3d41d46438ecf0f687319e7ff2_69f5b86fdc48703ced6ceec9.69f5b871dc48703ced6ceecb.69f5b8706db894508fc148f9:Trae CN.T(2026/5/2 16:40:17)

### DIFF
--- a/app/Http/Controllers/V1/Admin/Customer/CustomerStatsController.php
+++ b/app/Http/Controllers/V1/Admin/Customer/CustomerStatsController.php
@@ -62,6 +62,7 @@ class CustomerStatsController extends Controller
                 )
                     ->whereCompany()
                     ->whereCustomer($customer->id)
+                    ->where('status', '!=', Invoice::STATUS_VOID)
                     ->sum('base_total') ?? 0
             );
             array_push(
@@ -104,6 +105,7 @@ class CustomerStatsController extends Controller
         )
             ->whereCompany()
             ->whereCustomer($customer->id)
+            ->where('status', '!=', Invoice::STATUS_VOID)
             ->sum('base_total');
         $totalReceipts = Payment::whereBetween(
             'payment_date',

--- a/app/Http/Requests/DeleteInvoiceRequest.php
+++ b/app/Http/Requests/DeleteInvoiceRequest.php
@@ -3,7 +3,6 @@
 namespace App\Http\Requests;
 
 use App\Models\Invoice;
-use App\Rules\RelationNotExist;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -29,7 +28,6 @@ class DeleteInvoiceRequest extends FormRequest
             'ids.*' => [
                 'required',
                 Rule::exists('invoices', 'id'),
-                new RelationNotExist(Invoice::class, 'payments'),
             ],
         ];
     }

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -41,6 +41,8 @@ class Invoice extends Model implements HasMedia
 
     public const STATUS_PAID = 'PAID';
 
+    public const STATUS_VOID = 'VOID';
+
     protected $dates = [
         'created_at',
         'updated_at',
@@ -747,13 +749,28 @@ class Invoice extends Model implements HasMedia
         foreach ($ids as $id) {
             $invoice = self::find($id);
 
-            if ($invoice->transactions()->exists()) {
-                $invoice->transactions()->delete();
-            }
+            if ($invoice->payments()->exists()) {
+                $invoice->voidInvoice();
+            } else {
+                if ($invoice->transactions()->exists()) {
+                    $invoice->transactions()->delete();
+                }
 
-            $invoice->delete();
+                $invoice->delete();
+            }
         }
 
         return true;
+    }
+
+    public function voidInvoice(): void
+    {
+        $this->status = self::STATUS_VOID;
+        $this->save();
+    }
+
+    public function isVoid(): bool
+    {
+        return $this->status === self::STATUS_VOID;
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -407,6 +407,7 @@
     "number": "NUMBER",
     "amount_due": "AMOUNT DUE",
     "partially_paid": "Partially Paid",
+    "void": "Void",
     "total": "Total",
     "discount": "Discount",
     "sub_total": "Sub Total",
@@ -469,7 +470,7 @@
       "type_item_description": "Type Item Description (optional)"
     },
     "payment_attached_message": "One of the selected invoices already have a payment attached to it. Make sure to delete the attached payments first in order to go ahead with the removal",
-    "confirm_delete": "You will not be able to recover this Invoice | You will not be able to recover these Invoices",
+    "confirm_delete": "Invoices without payments will be permanently deleted. Invoices with payments will be voided (record kept). | Invoices without payments will be permanently deleted. Invoices with payments will be voided (record kept).",
     "created_message": "Invoice created successfully",
     "updated_message": "Invoice updated successfully",
     "deleted_message": "Invoice deleted successfully | Invoices deleted successfully",

--- a/lang/zh-cn.json
+++ b/lang/zh-cn.json
@@ -407,6 +407,7 @@
     "number": "NUMBER",
     "amount_due": "AMOUNT DUE",
     "partially_paid": "Partially Paid",
+    "void": "Void",
     "total": "Total",
     "discount": "Discount",
     "sub_total": "Sub Total",
@@ -469,7 +470,7 @@
       "type_item_description": "Type Item Description (optional)"
     },
     "payment_attached_message": "One of the selected invoices already have a payment attached to it. Make sure to delete the attached payments first in order to go ahead with the removal",
-    "confirm_delete": "You will not be able to recover this Invoice | You will not be able to recover these Invoices",
+    "confirm_delete": "Invoices without payments will be permanently deleted. Invoices with payments will be voided (record kept). | Invoices without payments will be permanently deleted. Invoices with payments will be voided (record kept).",
     "created_message": "Invoice created successfully",
     "updated_message": "Invoice updated successfully",
     "deleted_message": "Invoice deleted successfully | Invoices deleted successfully",

--- a/resources/scripts/components/base/BaseInvoiceStatusBadge.vue
+++ b/resources/scripts/components/base/BaseInvoiceStatusBadge.vue
@@ -37,6 +37,8 @@ export default {
           return 'bg-blue-400/25 px-2  py-1 text-sm  text-blue-900 uppercase font-normal text-center'
         case 'PAID':
           return 'bg-green-500/25 px-2 py-1 text-sm  text-green-900 uppercase font-normal text-center'
+        case 'VOID':
+          return 'bg-gray-500/25 px-2 py-1 text-sm text-gray-900 uppercase font-normal text-center'
         default:
           return 'bg-gray-500/25 px-2 py-1 text-sm  text-gray-900 uppercase font-normal text-center'
       }

--- a/resources/scripts/components/base/BaseInvoiceStatusLabel.vue
+++ b/resources/scripts/components/base/BaseInvoiceStatusLabel.vue
@@ -36,6 +36,8 @@ const labelStatus = computed(() => {
       return t('invoices.partially_paid')
     case 'PAID':
       return t('invoices.paid')
+    case 'VOID':
+      return t('invoices.void')
     default:
       return props.status
   }

--- a/resources/scripts/helpers/error-handling.js
+++ b/resources/scripts/helpers/error-handling.js
@@ -64,7 +64,7 @@ export const showError = (error) => {
     case 'payments_attached':
       showToaster('settings.payment_modes.payments_attached')
       break
-    
+
     case 'expenses_attached':
       showToaster('settings.payment_modes.expenses_attached')
       break


### PR DESCRIPTION
实现发票作废功能，包含以下修改：
- 添加VOID状态常量及相关方法
- 更新删除逻辑，有付款记录的发票改为作废处理
- 添加多语言支持和状态显示组件
- 在客户统计中排除已作废发票