### PR TITLE
.1502411993651747:448c3e07dbfaa164ecdbd75522a4e36d_69f5c516dc48703ced6cf2ea.69f5c51bdc48703ced6cf2ec.69f5c51b6db894508fc148fe:Trae CN.T(2026/5/2 17:34:19)

### DIFF
--- a/app/Http/Controllers/V1/Admin/Customer/CustomerStatsController.php
+++ b/app/Http/Controllers/V1/Admin/Customer/CustomerStatsController.php
@@ -62,6 +62,7 @@ class CustomerStatsController extends Controller
                 )
                     ->whereCompany()
                     ->whereCustomer($customer->id)
+                    ->where('status', '!=', Invoice::STATUS_VOID)
                     ->sum('base_total') ?? 0
             );
             array_push(
@@ -104,6 +105,7 @@ class CustomerStatsController extends Controller
         )
             ->whereCompany()
             ->whereCustomer($customer->id)
+            ->where('status', '!=', Invoice::STATUS_VOID)
             ->sum('base_total');
         $totalReceipts = Payment::whereBetween(
             'payment_date',

--- a/app/Http/Controllers/V1/Admin/Customer/CustomerStatsController.php
+++ b/app/Http/Controllers/V1/Admin/Customer/CustomerStatsController.php
@@ -83,7 +83,12 @@ class CustomerStatsController extends Controller
                 )
                     ->whereCompany()
                     ->whereCustomer($customer->id)
-                    ->sum('base_amount') ?? 0
+                    ->leftJoin('invoices', 'invoices.id', '=', 'payments.invoice_id')
+                    ->where(function ($query) {
+                        $query->whereNull('invoices.id')
+                            ->orWhere('invoices.status', '!=', Invoice::STATUS_VOID);
+                    })
+                    ->sum('payments.base_amount') ?? 0
             );
             array_push(
                 $netProfits,
@@ -113,7 +118,12 @@ class CustomerStatsController extends Controller
         )
             ->whereCompany()
             ->whereCustomer($customer->id)
-            ->sum('base_amount');
+            ->leftJoin('invoices', 'invoices.id', '=', 'payments.invoice_id')
+            ->where(function ($query) {
+                $query->whereNull('invoices.id')
+                    ->orWhere('invoices.status', '!=', Invoice::STATUS_VOID);
+            })
+            ->sum('payments.base_amount');
         $totalExpenses = Expense::whereBetween(
             'expense_date',
             [$startDate->format('Y-m-d'), $start->format('Y-m-d')]

--- a/app/Http/Controllers/V1/Admin/Invoice/InvoicesController.php
+++ b/app/Http/Controllers/V1/Admin/Invoice/InvoicesController.php
@@ -104,10 +104,12 @@ class InvoicesController extends Controller
             ->whereIn('id', $request->ids)
             ->pluck('id');
 
-        Invoice::deleteInvoices($ids);
+        $result = Invoice::deleteInvoices($ids);
 
         return response()->json([
             'success' => true,
+            'voided_count' => $result['voided_count'],
+            'deleted_count' => $result['deleted_count'],
         ]);
     }
 }

--- a/app/Http/Controllers/V1/Admin/Payment/PaymentsController.php
+++ b/app/Http/Controllers/V1/Admin/Payment/PaymentsController.php
@@ -29,6 +29,7 @@ class PaymentsController extends Controller
             ->leftJoin('payment_methods', 'payment_methods.id', '=', 'payments.payment_method_id')
             ->applyFilters($request->all())
             ->select('payments.*', 'customers.name', 'invoices.invoice_number', 'payment_methods.name as payment_mode')
+            ->with('invoice')
             ->latest()
             ->paginateData($limit);
 

--- a/app/Http/Requests/DeleteInvoiceRequest.php
+++ b/app/Http/Requests/DeleteInvoiceRequest.php
@@ -3,7 +3,6 @@
 namespace App\Http\Requests;
 
 use App\Models\Invoice;
-use App\Rules\RelationNotExist;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -29,7 +28,6 @@ class DeleteInvoiceRequest extends FormRequest
             'ids.*' => [
                 'required',
                 Rule::exists('invoices', 'id'),
-                new RelationNotExist(Invoice::class, 'payments'),
             ],
         ];
     }

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -41,6 +41,8 @@ class Invoice extends Model implements HasMedia
 
     public const STATUS_PAID = 'PAID';
 
+    public const STATUS_VOID = 'VOID';
+
     protected $dates = [
         'created_at',
         'updated_at',
@@ -747,13 +749,28 @@ class Invoice extends Model implements HasMedia
         foreach ($ids as $id) {
             $invoice = self::find($id);
 
-            if ($invoice->transactions()->exists()) {
-                $invoice->transactions()->delete();
-            }
+            if ($invoice->payments()->exists()) {
+                $invoice->voidInvoice();
+            } else {
+                if ($invoice->transactions()->exists()) {
+                    $invoice->transactions()->delete();
+                }
 
-            $invoice->delete();
+                $invoice->delete();
+            }
         }
 
         return true;
+    }
+
+    public function voidInvoice(): void
+    {
+        $this->status = self::STATUS_VOID;
+        $this->save();
+    }
+
+    public function isVoid(): bool
+    {
+        return $this->status === self::STATUS_VOID;
     }
 }

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -224,7 +224,8 @@ class Invoice extends Model implements HasMedia
 
     public function scopeWherePaidStatus($query, $status)
     {
-        return $query->where('invoices.paid_status', $status);
+        return $query->where('invoices.paid_status', $status)
+            ->where('invoices.status', '!=', self::STATUS_VOID);
     }
 
     public function scopeWhereDueStatus($query, $status)
@@ -232,7 +233,7 @@ class Invoice extends Model implements HasMedia
         return $query->whereIn('invoices.paid_status', [
             self::STATUS_UNPAID,
             self::STATUS_PARTIALLY_PAID,
-        ]);
+        ])->where('invoices.status', '!=', self::STATUS_VOID);
     }
 
     public function scopeWhereInvoiceNumber($query, $invoiceNumber)
@@ -746,21 +747,29 @@ class Invoice extends Model implements HasMedia
 
     public static function deleteInvoices($ids)
     {
+        $voidedCount = 0;
+        $deletedCount = 0;
+
         foreach ($ids as $id) {
             $invoice = self::find($id);
 
             if ($invoice->payments()->exists()) {
                 $invoice->voidInvoice();
+                $voidedCount++;
             } else {
                 if ($invoice->transactions()->exists()) {
                     $invoice->transactions()->delete();
                 }
 
                 $invoice->delete();
+                $deletedCount++;
             }
         }
 
-        return true;
+        return [
+            'voided_count' => $voidedCount,
+            'deleted_count' => $deletedCount,
+        ];
     }
 
     public function voidInvoice(): void

--- a/lang/en.json
+++ b/lang/en.json
@@ -407,6 +407,7 @@
     "number": "NUMBER",
     "amount_due": "AMOUNT DUE",
     "partially_paid": "Partially Paid",
+    "void": "Void",
     "total": "Total",
     "discount": "Discount",
     "sub_total": "Sub Total",
@@ -469,7 +470,7 @@
       "type_item_description": "Type Item Description (optional)"
     },
     "payment_attached_message": "One of the selected invoices already have a payment attached to it. Make sure to delete the attached payments first in order to go ahead with the removal",
-    "confirm_delete": "You will not be able to recover this Invoice | You will not be able to recover these Invoices",
+    "confirm_delete": "Invoices without payments will be permanently deleted. Invoices with payments will be voided (record kept). | Invoices without payments will be permanently deleted. Invoices with payments will be voided (record kept).",
     "created_message": "Invoice created successfully",
     "updated_message": "Invoice updated successfully",
     "deleted_message": "Invoice deleted successfully | Invoices deleted successfully",

--- a/lang/en.json
+++ b/lang/en.json
@@ -474,6 +474,8 @@
     "created_message": "Invoice created successfully",
     "updated_message": "Invoice updated successfully",
     "deleted_message": "Invoice deleted successfully | Invoices deleted successfully",
+    "voided_message": "Invoice voided successfully | Invoices voided successfully",
+    "voided_and_deleted_message": "Invoice voided and deleted successfully | Invoices voided and deleted successfully",
     "marked_as_sent_message": "Invoice marked as sent successfully",
     "something_went_wrong": "something went wrong",
     "invalid_due_amount_message": "Total Invoice amount cannot be less than total paid amount for this Invoice. Please update the invoice or delete the associated payments to continue.",

--- a/lang/zh-cn.json
+++ b/lang/zh-cn.json
@@ -474,6 +474,8 @@
     "created_message": "Invoice created successfully",
     "updated_message": "Invoice updated successfully",
     "deleted_message": "Invoice deleted successfully | Invoices deleted successfully",
+    "voided_message": "发票已作废 | 发票已作废",
+    "voided_and_deleted_message": "部分发票已作废，部分已删除 | 部分发票已作废，部分已删除",
     "marked_as_sent_message": "Invoice marked as sent successfully",
     "something_went_wrong": "something went wrong",
     "invalid_due_amount_message": "Total Invoice amount cannot be less than total paid amount for this Invoice. Please update the invoice or delete the associated payments to continue.",

--- a/lang/zh-cn.json
+++ b/lang/zh-cn.json
@@ -407,6 +407,7 @@
     "number": "NUMBER",
     "amount_due": "AMOUNT DUE",
     "partially_paid": "Partially Paid",
+    "void": "Void",
     "total": "Total",
     "discount": "Discount",
     "sub_total": "Sub Total",
@@ -469,7 +470,7 @@
       "type_item_description": "Type Item Description (optional)"
     },
     "payment_attached_message": "One of the selected invoices already have a payment attached to it. Make sure to delete the attached payments first in order to go ahead with the removal",
-    "confirm_delete": "You will not be able to recover this Invoice | You will not be able to recover these Invoices",
+    "confirm_delete": "Invoices without payments will be permanently deleted. Invoices with payments will be voided (record kept). | Invoices without payments will be permanently deleted. Invoices with payments will be voided (record kept).",
     "created_message": "Invoice created successfully",
     "updated_message": "Invoice updated successfully",
     "deleted_message": "Invoice deleted successfully | Invoices deleted successfully",

--- a/resources/scripts/admin/stores/invoice.js
+++ b/resources/scripts/admin/stores/invoice.js
@@ -245,14 +245,30 @@ export const useInvoiceStore = (useWindow = false) => {
           http
             .post(`/api/v1/invoices/delete`, id)
             .then((response) => {
-              let index = this.invoices.findIndex(
-                (invoice) => invoice.id === id,
-              )
-              this.invoices.splice(index, 1)
+              const voidedCount = response.data.voided_count || 0
+              const deletedCount = response.data.deleted_count || 0
+              let message = ''
+
+              if (voidedCount > 0 && deletedCount > 0) {
+                message = global.t('invoices.voided_and_deleted_message', 1)
+              } else if (voidedCount > 0) {
+                message = global.t('invoices.voided_message', 1)
+              } else {
+                message = global.t('invoices.deleted_message', 1)
+              }
+
+              if (deletedCount > 0) {
+                let index = this.invoices.findIndex(
+                  (invoice) => invoice.id === id.id || invoice.id === id,
+                )
+                if (index !== -1) {
+                  this.invoices.splice(index, 1)
+                }
+              }
 
               notificationStore.showNotification({
                 type: 'success',
-                message: global.t('invoices.deleted_message', 1),
+                message: message,
               })
               resolve(response)
             })
@@ -268,17 +284,24 @@ export const useInvoiceStore = (useWindow = false) => {
           http
             .post(`/api/v1/invoices/delete`, { ids: this.selectedInvoices })
             .then((response) => {
-              this.selectedInvoices.forEach((invoice) => {
-                let index = this.invoices.findIndex(
-                  (_inv) => _inv.id === invoice.id,
-                )
-                this.invoices.splice(index, 1)
-              })
+              const voidedCount = response.data.voided_count || 0
+              const deletedCount = response.data.deleted_count || 0
+              const totalCount = voidedCount + deletedCount
+              let message = ''
+
+              if (voidedCount > 0 && deletedCount > 0) {
+                message = global.t('invoices.voided_and_deleted_message', totalCount > 1 ? 2 : 1)
+              } else if (voidedCount > 0) {
+                message = global.t('invoices.voided_message', totalCount > 1 ? 2 : 1)
+              } else {
+                message = global.t('invoices.deleted_message', totalCount > 1 ? 2 : 1)
+              }
+
               this.selectedInvoices = []
 
               notificationStore.showNotification({
                 type: 'success',
-                message: global.t('invoices.deleted_message', 2),
+                message: message,
               })
               resolve(response)
             })

--- a/resources/scripts/admin/views/payments/Index.vue
+++ b/resources/scripts/admin/views/payments/Index.vue
@@ -175,12 +175,19 @@
         </template>
 
         <template #cell-invoice_number="{ row }">
-          <span>
-            {{
-              row?.data?.invoice?.invoice_number
-                ? row?.data?.invoice?.invoice_number
-                : '-'
-            }}
+          <span class="flex items-center gap-2">
+            <template v-if="row?.data?.invoice">
+              <template v-if="row.data.invoice.status === 'VOID'">
+                <span class="text-sm text-gray-500 line-through">{{ row.data.invoice.invoice_number }}</span>
+                <BaseInvoiceStatusBadge status="VOID">
+                  VOID
+                </BaseInvoiceStatusBadge>
+              </template>
+              <template v-else>
+                <span>{{ row.data.invoice.invoice_number }}</span>
+              </template>
+            </template>
+            <span v-else>-</span>
           </span>
         </template>
 
@@ -213,6 +220,7 @@ import abilities from '@/scripts/admin/stub/abilities'
 import CapsuleIcon from '@/scripts/components/icons/empty/CapsuleIcon.vue'
 import PaymentDropdown from '@/scripts/admin/components/dropdowns/PaymentIndexDropdown.vue'
 import SendPaymentModal from '@/scripts/admin/components/modal-components/SendPaymentModal.vue'
+import BaseInvoiceStatusBadge from '@/scripts/components/base/BaseInvoiceStatusBadge.vue'
 
 const { t } = useI18n()
 let showFilters = ref(false)

--- a/resources/scripts/components/base/BaseInvoiceStatusBadge.vue
+++ b/resources/scripts/components/base/BaseInvoiceStatusBadge.vue
@@ -37,6 +37,8 @@ export default {
           return 'bg-blue-400/25 px-2  py-1 text-sm  text-blue-900 uppercase font-normal text-center'
         case 'PAID':
           return 'bg-green-500/25 px-2 py-1 text-sm  text-green-900 uppercase font-normal text-center'
+        case 'VOID':
+          return 'bg-gray-500/25 px-2 py-1 text-sm text-gray-900 uppercase font-normal text-center'
         default:
           return 'bg-gray-500/25 px-2 py-1 text-sm  text-gray-900 uppercase font-normal text-center'
       }

--- a/resources/scripts/components/base/BaseInvoiceStatusLabel.vue
+++ b/resources/scripts/components/base/BaseInvoiceStatusLabel.vue
@@ -36,6 +36,8 @@ const labelStatus = computed(() => {
       return t('invoices.partially_paid')
     case 'PAID':
       return t('invoices.paid')
+    case 'VOID':
+      return t('invoices.void')
     default:
       return props.status
   }

--- a/resources/scripts/helpers/error-handling.js
+++ b/resources/scripts/helpers/error-handling.js
@@ -64,7 +64,7 @@ export const showError = (error) => {
     case 'payments_attached':
       showToaster('settings.payment_modes.payments_attached')
       break
-    
+
     case 'expenses_attached':
       showToaster('settings.payment_modes.expenses_attached')
       break


### PR DESCRIPTION
本轮补齐发票作废后的状态同步逻辑：后端筛选 paid/partially paid/due 时排除 VOID 发票，删除接口返回作废和删除数量；前端根据返回结果显示删除或作废提示；收款列表展示关联发票的 VOID 状态；客户统计中的收款金额排除关联 VOID 发票的 payment，保持发票、收款、客户统计口径一致。