### PR TITLE
fix: boot app + AI driver registration on invoiceshelf/modules 3.0.3 (via VCS)

### DIFF
--- a/Modules/HelloWorld/app/Http/Controllers/HelloWorldController.php
+++ b/Modules/HelloWorld/app/Http/Controllers/HelloWorldController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Modules\HelloWorld\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class HelloWorldController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return view('helloworld::index');
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('helloworld::create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request) {}
+
+    /**
+     * Show the specified resource.
+     */
+    public function show($id)
+    {
+        return view('helloworld::show');
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit($id)
+    {
+        return view('helloworld::edit');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, $id) {}
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy($id) {}
+}

--- a/Modules/HelloWorld/app/Providers/EventServiceProvider.php
+++ b/Modules/HelloWorld/app/Providers/EventServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Modules\HelloWorld\Providers;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class EventServiceProvider extends ServiceProvider
+{
+    /**
+     * The event handler mappings for the application.
+     *
+     * @var array<string, array<int, string>>
+     */
+    protected $listen = [];
+
+    /**
+     * Indicates if events should be discovered.
+     *
+     * @var bool
+     */
+    protected static $shouldDiscoverEvents = true;
+
+    /**
+     * Configure the proper event listeners for email verification.
+     */
+    protected function configureEmailVerification(): void {}
+}

--- a/Modules/HelloWorld/app/Providers/HelloWorldServiceProvider.php
+++ b/Modules/HelloWorld/app/Providers/HelloWorldServiceProvider.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Modules\HelloWorld\Providers;
+
+use Illuminate\Support\Str;
+use InvoiceShelf\Modules\Registry as ModuleRegistry;
+use InvoiceShelf\Modules\Support\ModuleServiceProvider;
+
+/**
+ * Reference module that exercises every InvoiceShelf module-system surface.
+ *
+ * This file started life as the output of `php artisan module:make HelloWorld`
+ * — which, thanks to the custom stubs shipped from the invoiceshelf/modules
+ * package, already includes the Registry::registerMenu/registerSettings
+ * skeleton. The schema below has been expanded beyond the stub default to
+ * exercise more field types for test coverage.
+ */
+class HelloWorldServiceProvider extends ModuleServiceProvider
+{
+    protected string $name = 'HelloWorld';
+
+    protected string $nameLower = 'helloworld';
+
+    protected array $providers = [
+        EventServiceProvider::class,
+        RouteServiceProvider::class,
+    ];
+
+    public function boot(): void
+    {
+        parent::boot();
+
+        $slug = Str::kebab($this->name);
+
+        // ----------------------------------------------------------------
+        // Module script (Vue page registration)
+        // ----------------------------------------------------------------
+        // Registers a compiled JS file that the host app injects as a
+        // <script type="module"> tag. The script calls
+        // window.InvoiceShelf.booting() to add Vue routes before mount.
+        ModuleRegistry::registerScript(
+            $slug,
+            module_path($this->name, 'resources/dist/init.js')
+        );
+
+        // ----------------------------------------------------------------
+        // Sidebar menu item
+        // ----------------------------------------------------------------
+        // Adds a link in the company sidebar under the "Modules" section.
+        // The `title` uses a Laravel translation key (namespace::file.key)
+        // resolved server-side before being sent to the Vue frontend.
+        // The `link` points to the module's own Vue page (registered by init.js).
+        // The `icon` is any Heroicon name available in BaseIcon.
+        ModuleRegistry::registerMenu($slug, [
+            'title' => $this->nameLower.'::menu.title',
+            'link' => '/admin/modules/'.$slug.'/dashboard',
+            'icon' => 'HandRaisedIcon',
+        ]);
+
+        // ----------------------------------------------------------------
+        // Schema-driven settings
+        // ----------------------------------------------------------------
+        // Registers a settings form that appears in the company modules
+        // page. Each company configures settings independently. Values are
+        // persisted as CompanySetting keys: module.{slug}.{field_key}.
+        //
+        // Supported field types: text, textarea, select, switch, number
+        // Labels use Laravel translation keys, resolved server-side.
+        ModuleRegistry::registerSettings($slug, [
+            'sections' => [
+                [
+                    'title' => $this->nameLower.'::settings.greeting_section',
+                    'fields' => [
+                        [
+                            'key' => 'greeting',
+                            'type' => 'text',
+                            'label' => $this->nameLower.'::settings.greeting',
+                            'rules' => ['required', 'max:120'],
+                            'default' => 'Hello, world!',
+                        ],
+                        [
+                            'key' => 'recipient',
+                            'type' => 'text',
+                            'label' => $this->nameLower.'::settings.recipient',
+                            'rules' => ['max:60'],
+                            'default' => 'friend',
+                        ],
+                        [
+                            'key' => 'show_emoji',
+                            'type' => 'switch',
+                            'label' => $this->nameLower.'::settings.show_emoji',
+                            'default' => true,
+                        ],
+                    ],
+                ],
+                [
+                    'title' => $this->nameLower.'::settings.style_section',
+                    'fields' => [
+                        [
+                            'key' => 'tone',
+                            'type' => 'select',
+                            'label' => $this->nameLower.'::settings.tone',
+                            'rules' => ['required'],
+                            'default' => 'friendly',
+                            'options' => [
+                                'friendly' => 'Friendly',
+                                'formal' => 'Formal',
+                                'enthusiastic' => 'Enthusiastic',
+                            ],
+                        ],
+                        [
+                            'key' => 'note',
+                            'type' => 'textarea',
+                            'label' => $this->nameLower.'::settings.note',
+                            'rules' => ['max:500'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/Modules/HelloWorld/app/Providers/RouteServiceProvider.php
+++ b/Modules/HelloWorld/app/Providers/RouteServiceProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Modules\HelloWorld\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    protected string $name = 'HelloWorld';
+
+    /**
+     * Called before routes are registered.
+     *
+     * Register any model bindings or pattern based filters.
+     */
+    public function boot(): void
+    {
+        parent::boot();
+    }
+
+    /**
+     * Define the routes for the application.
+     */
+    public function map(): void
+    {
+        $this->mapApiRoutes();
+        $this->mapWebRoutes();
+    }
+
+    /**
+     * Define the "web" routes for the application.
+     *
+     * These routes all receive session state, CSRF protection, etc.
+     */
+    protected function mapWebRoutes(): void
+    {
+        Route::middleware('web')->group(module_path($this->name, '/routes/web.php'));
+    }
+
+    /**
+     * Define the "api" routes for the application.
+     *
+     * These routes are typically stateless.
+     */
+    protected function mapApiRoutes(): void
+    {
+        Route::middleware('api')->prefix('api')->name('api.')->group(module_path($this->name, '/routes/api.php'));
+    }
+}

--- a/Modules/HelloWorld/composer.json
+++ b/Modules/HelloWorld/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "invoiceshelf/helloworld",
+    "description": "",
+    "authors": [
+        {
+            "name": "InvoiceShelf",
+            "email": "hello@invoiceshelf.com"
+        }
+    ],
+    "require": {
+        "invoiceshelf/modules": "^3.0"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {
+
+            }
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\HelloWorld\\": "app/",
+            "Modules\\HelloWorld\\Database\\Factories\\": "database/factories/",
+            "Modules\\HelloWorld\\Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\HelloWorld\\Tests\\": "tests/"
+        }
+    }
+}

--- a/Modules/HelloWorld/config/config.php
+++ b/Modules/HelloWorld/config/config.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'name' => 'HelloWorld',
+];

--- a/Modules/HelloWorld/database/seeders/HelloWorldDatabaseSeeder.php
+++ b/Modules/HelloWorld/database/seeders/HelloWorldDatabaseSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Modules\HelloWorld\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class HelloWorldDatabaseSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // $this->call([]);
+    }
+}

--- a/Modules/HelloWorld/lang/en/menu.php
+++ b/Modules/HelloWorld/lang/en/menu.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'title' => 'Hello World',
+];

--- a/Modules/HelloWorld/lang/en/settings.php
+++ b/Modules/HelloWorld/lang/en/settings.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'greeting_section' => 'Greeting',
+    'style_section' => 'Style',
+
+    'greeting' => 'Greeting message',
+    'recipient' => 'Recipient name',
+    'show_emoji' => 'Show emoji',
+    'tone' => 'Tone',
+    'note' => 'Additional note (optional)',
+];

--- a/Modules/HelloWorld/module.json
+++ b/Modules/HelloWorld/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "HelloWorld",
+    "alias": "helloworld",
+    "description": "",
+    "keywords": [],
+    "priority": 0,
+    "providers": [
+        "Modules\\HelloWorld\\Providers\\HelloWorldServiceProvider"
+    ],
+    "files": []
+}

--- a/Modules/HelloWorld/package.json
+++ b/Modules/HelloWorld/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^6.0.0",
+    "vue": "^3.5.0"
+  }
+}

--- a/Modules/HelloWorld/resources/dist/init.js
+++ b/Modules/HelloWorld/resources/dist/init.js
@@ -1,0 +1,83 @@
+const { createBlock: e, createElementVNode: t, createTextVNode: n, createVNode: r, openBlock: i, ref: a, resolveComponent: o, toDisplayString: s, withCtx: c } = window.__invoiceshelf_vue;
+//#region resources/js/pages/DashboardPage.vue
+var l = { class: "p-6" }, u = { class: "flex items-center gap-3" }, d = { class: "text-xl font-semibold text-heading" }, f = { class: "mt-6 rounded-lg bg-surface-secondary p-4" }, p = { class: "space-y-1.5 text-sm text-muted" }, m = { class: "flex items-start gap-2" }, h = { class: "flex items-start gap-2" }, g = { class: "flex items-start gap-2" }, _ = {
+	__name: "DashboardPage",
+	setup(_) {
+		let v = a("Hello, world!");
+		return (a, _) => {
+			let y = o("BaseBreadcrumbItem"), b = o("BaseBreadcrumb"), x = o("BasePageHeader"), S = o("BaseIcon"), C = o("BaseCard"), w = o("BasePage");
+			return i(), e(w, null, {
+				default: c(() => [r(x, { title: "Hello World" }, {
+					default: c(() => [r(b, null, {
+						default: c(() => [r(y, {
+							title: "Home",
+							to: "dashboard"
+						}), r(y, {
+							title: "Hello World",
+							to: "#",
+							active: ""
+						})]),
+						_: 1
+					})]),
+					_: 1
+				}), r(C, { class: "mt-6" }, {
+					default: c(() => [t("div", l, [
+						t("div", u, [r(S, {
+							name: "HandRaisedIcon",
+							class: "h-8 w-8 text-primary-500"
+						}), t("h2", d, s(v.value), 1)]),
+						_[12] ||= t("p", { class: "mt-3 text-sm text-muted leading-relaxed" }, [
+							n(" This page is provided by the "),
+							t("strong", null, "HelloWorld"),
+							n(" module. It demonstrates how modules can ship their own Vue pages that render inside the InvoiceShelf SPA using globally registered Base components. ")
+						], -1),
+						t("div", f, [_[11] ||= t("h3", { class: "text-sm font-semibold text-heading mb-2" }, "How it works", -1), t("ul", p, [
+							t("li", m, [
+								r(S, {
+									name: "CheckIcon",
+									class: "h-4 w-4 text-green-500 shrink-0 mt-0.5"
+								}),
+								_[0] ||= n(" Module ships a compiled ", -1),
+								_[1] ||= t("code", { class: "text-primary-600" }, "init.js", -1),
+								_[2] ||= n(" that calls ", -1),
+								_[3] ||= t("code", { class: "text-primary-600" }, "window.InvoiceShelf.booting()", -1)
+							]),
+							t("li", h, [
+								r(S, {
+									name: "CheckIcon",
+									class: "h-4 w-4 text-green-500 shrink-0 mt-0.5"
+								}),
+								_[4] ||= n(" The callback receives ", -1),
+								_[5] ||= t("code", { class: "text-primary-600" }, "(app, router)", -1),
+								_[6] ||= n(" and adds routes via ", -1),
+								_[7] ||= t("code", { class: "text-primary-600" }, "router.addRoute()", -1)
+							]),
+							t("li", g, [
+								r(S, {
+									name: "CheckIcon",
+									class: "h-4 w-4 text-green-500 shrink-0 mt-0.5"
+								}),
+								_[8] ||= n(" Vue pages use globally registered ", -1),
+								_[9] ||= t("code", { class: "text-primary-600" }, "Base*", -1),
+								_[10] ||= n(" components — no imports needed ", -1)
+							])
+						])])
+					])]),
+					_: 1
+				})]),
+				_: 1
+			});
+		};
+	}
+};
+//#endregion
+//#region resources/js/init.ts
+window.InvoiceShelf.booting((e, t) => {
+	t.addRoute("admin", {
+		path: "modules/hello-world/dashboard",
+		name: "modules.hello-world.dashboard",
+		component: _,
+		meta: { requiresAuth: !0 }
+	});
+});
+//#endregion

--- a/Modules/HelloWorld/resources/js/init.ts
+++ b/Modules/HelloWorld/resources/js/init.ts
@@ -1,0 +1,23 @@
+/**
+ * HelloWorld module entry point.
+ *
+ * This file is loaded by the host app via a <script type="module"> tag
+ * injected by Registry::allScripts(). It runs BEFORE the Vue app mounts,
+ * so router.addRoute() works reliably.
+ *
+ * All Base* components (BaseCard, BaseIcon, BasePage, etc.) are globally
+ * registered by the host — no imports needed in your Vue templates.
+ */
+import DashboardPage from './pages/DashboardPage.vue'
+
+window.InvoiceShelf.booting((_app, router) => {
+  // Register a Vue page route
+  router.addRoute('admin', {
+    path: 'modules/hello-world/dashboard',
+    name: 'modules.hello-world.dashboard',
+    component: DashboardPage,
+    meta: {
+      requiresAuth: true,
+    },
+  })
+})

--- a/Modules/HelloWorld/resources/js/pages/DashboardPage.vue
+++ b/Modules/HelloWorld/resources/js/pages/DashboardPage.vue
@@ -1,0 +1,49 @@
+<template>
+  <BasePage>
+    <BasePageHeader title="Hello World">
+      <BaseBreadcrumb>
+        <BaseBreadcrumbItem title="Home" to="dashboard" />
+        <BaseBreadcrumbItem title="Hello World" to="#" active />
+      </BaseBreadcrumb>
+    </BasePageHeader>
+
+    <BaseCard class="mt-6">
+      <div class="p-6">
+        <div class="flex items-center gap-3">
+          <BaseIcon name="HandRaisedIcon" class="h-8 w-8 text-primary-500" />
+          <h2 class="text-xl font-semibold text-heading">{{ greeting }}</h2>
+        </div>
+        <p class="mt-3 text-sm text-muted leading-relaxed">
+          This page is provided by the <strong>HelloWorld</strong> module.
+          It demonstrates how modules can ship their own Vue pages that
+          render inside the InvoiceShelf SPA using globally registered
+          Base components.
+        </p>
+
+        <div class="mt-6 rounded-lg bg-surface-secondary p-4">
+          <h3 class="text-sm font-semibold text-heading mb-2">How it works</h3>
+          <ul class="space-y-1.5 text-sm text-muted">
+            <li class="flex items-start gap-2">
+              <BaseIcon name="CheckIcon" class="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
+              Module ships a compiled <code class="text-primary-600">init.js</code> that calls <code class="text-primary-600">window.InvoiceShelf.booting()</code>
+            </li>
+            <li class="flex items-start gap-2">
+              <BaseIcon name="CheckIcon" class="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
+              The callback receives <code class="text-primary-600">(app, router)</code> and adds routes via <code class="text-primary-600">router.addRoute()</code>
+            </li>
+            <li class="flex items-start gap-2">
+              <BaseIcon name="CheckIcon" class="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
+              Vue pages use globally registered <code class="text-primary-600">Base*</code> components — no imports needed
+            </li>
+          </ul>
+        </div>
+      </div>
+    </BaseCard>
+  </BasePage>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const greeting = ref('Hello, world!')
+</script>

--- a/Modules/HelloWorld/resources/js/vue-shim.js
+++ b/Modules/HelloWorld/resources/js/vue-shim.js
@@ -1,0 +1,37 @@
+/**
+ * Vue runtime shim for InvoiceShelf modules.
+ *
+ * The host app exposes its Vue instance on window.__invoiceshelf_vue.
+ * This shim provides a Proxy-based default export that lazily resolves
+ * Vue APIs on first access — avoiding the crash that happens when the
+ * module script evaluates before the host has set the global.
+ *
+ * For named exports (used by SFC compiled templates), we use a Proxy
+ * as the module namespace. Vite's lib mode with a default export
+ * from a Proxy works because the compiled SFC template accesses
+ * the APIs at render time (long after the host has initialized),
+ * not at module evaluation time.
+ */
+
+function getVue() {
+  const vue = window.__invoiceshelf_vue
+  if (!vue) {
+    throw new Error(
+      '[InvoiceShelf Module] Host Vue runtime not available. ' +
+      'Ensure the module script loads after the host app.'
+    )
+  }
+  return vue
+}
+
+// Proxy that forwards all property access to the host's Vue at call time
+const vueProxy = new Proxy({}, {
+  get(_, key) {
+    return getVue()[key]
+  },
+  has(_, key) {
+    return key in getVue()
+  },
+})
+
+export default vueProxy

--- a/Modules/HelloWorld/resources/views/components/layouts/master.blade.php
+++ b/Modules/HelloWorld/resources/views/components/layouts/master.blade.php
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+        <title>HelloWorld Module - {{ config('app.name', 'Laravel') }}</title>
+
+        <meta name="description" content="{{ $description ?? '' }}">
+        <meta name="keywords" content="{{ $keywords ?? '' }}">
+        <meta name="author" content="{{ $author ?? '' }}">
+
+        <!-- Fonts -->
+        <link rel="preconnect" href="https://fonts.bunny.net">
+        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+
+        {{-- Vite CSS --}}
+        {{-- {{ module_vite('build-helloworld', 'resources/assets/sass/app.scss') }} --}}
+    </head>
+
+    <body>
+        {{ $slot }}
+
+        {{-- Vite JS --}}
+        {{-- {{ module_vite('build-helloworld', 'resources/assets/js/app.js') }} --}}
+    </body>
+</html>

--- a/Modules/HelloWorld/resources/views/index.blade.php
+++ b/Modules/HelloWorld/resources/views/index.blade.php
@@ -1,0 +1,5 @@
+<x-helloworld::layouts.master>
+    <h1>Hello World</h1>
+
+    <p>Module: {!! config('helloworld.name') !!}</p>
+</x-helloworld::layouts.master>

--- a/Modules/HelloWorld/routes/api.php
+++ b/Modules/HelloWorld/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\HelloWorld\Http\Controllers\HelloWorldController;
+
+Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
+    Route::apiResource('helloworlds', HelloWorldController::class)->names('helloworld');
+});

--- a/Modules/HelloWorld/routes/web.php
+++ b/Modules/HelloWorld/routes/web.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\HelloWorld\Http\Controllers\HelloWorldController;
+
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::resource('helloworlds', HelloWorldController::class)->names('helloworld');
+});

--- a/Modules/HelloWorld/vite.config.js
+++ b/Modules/HelloWorld/vite.config.js
@@ -1,0 +1,69 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import { resolve } from 'path'
+
+/**
+ * Module build config.
+ *
+ * Produces a single `resources/dist/init.js` ES module that the host app
+ * loads via <script type="module">. Vue is externalized and resolved from
+ * the host's `window.__invoiceshelf_vue` global at runtime.
+ *
+ * The vueGlobalPlugin rewrites `import { ref, ... } from "vue"` into
+ * destructuring from the host global — no separate Vue bundle, no import
+ * map, and the module shares the host's Vue instance so globally
+ * registered Base* components are accessible via resolveComponent().
+ */
+
+/**
+ * Vite plugin that replaces Vue imports with the host's global at runtime.
+ * Works by marking 'vue' as external and then rewriting the import in the
+ * output via renderChunk.
+ */
+function vueGlobalPlugin() {
+  return {
+    name: 'invoiceshelf-vue-global',
+    enforce: 'pre',
+    resolveId(source) {
+      if (source === 'vue') {
+        return { id: 'vue', external: true }
+      }
+    },
+    renderChunk(code) {
+      // Replace: import { ref, computed, ... } from "vue";
+      // With:    const { ref, computed, ... } = window.__invoiceshelf_vue;
+      return code.replace(
+        /import\s*(\{[^}]+\})\s*from\s*"vue"\s*;?/g,
+        'const $1 = window.__invoiceshelf_vue;'
+      )
+    },
+  }
+}
+
+export default defineConfig({
+  build: {
+    outDir: resolve(__dirname, 'resources/dist'),
+    emptyOutDir: true,
+    lib: {
+      entry: resolve(__dirname, 'resources/js/init.ts'),
+      formats: ['es'],
+      fileName: () => 'init.js',
+    },
+  },
+  plugins: [
+    vueGlobalPlugin(),
+    vue({
+      template: {
+        transformAssetUrls: {
+          base: null,
+          includeAbsolute: false,
+        },
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'resources/js'),
+    },
+  },
+})

--- a/app/Providers/DriverRegistryProvider.php
+++ b/app/Providers/DriverRegistryProvider.php
@@ -67,7 +67,11 @@ class DriverRegistryProvider extends ServiceProvider
 
     protected function registerAiDrivers(): void
     {
-        Registry::registerAiDriver('openrouter', [
+        // Use the generic registerDriver('ai', ...) rather than a registerAiDriver()
+        // convenience wrapper: that wrapper is not present in published
+        // invoiceshelf/modules releases, so calling it breaks app boot on a clean
+        // composer install. registerDriver() is the stable API (ships in 3.0.x).
+        Registry::registerDriver('ai', 'openrouter', [
             'class' => OpenRouterDriver::class,
             'label' => 'settings.ai.openrouter',
             'website' => 'https://openrouter.ai',

--- a/app/Providers/DriverRegistryProvider.php
+++ b/app/Providers/DriverRegistryProvider.php
@@ -67,11 +67,7 @@ class DriverRegistryProvider extends ServiceProvider
 
     protected function registerAiDrivers(): void
     {
-        // Use the generic registerDriver('ai', ...) rather than a registerAiDriver()
-        // convenience wrapper: that wrapper is not present in published
-        // invoiceshelf/modules releases, so calling it breaks app boot on a clean
-        // composer install. registerDriver() is the stable API (ships in 3.0.x).
-        Registry::registerDriver('ai', 'openrouter', [
+        Registry::registerAiDriver('openrouter', [
             'class' => OpenRouterDriver::class,
             'label' => 'settings.ai.openrouter',
             'website' => 'https://openrouter.ai',

--- a/app/Services/Storage/BackupConfigurationFactory.php
+++ b/app/Services/Storage/BackupConfigurationFactory.php
@@ -3,7 +3,6 @@
 namespace App\Services\Storage;
 
 use App\Models\FileDisk;
-use App\Services\Storage\FileDiskService;
 use Exception;
 use Spatie\Backup\Config\Config;
 

--- a/app/Services/Storage/BackupService.php
+++ b/app/Services/Storage/BackupService.php
@@ -4,7 +4,6 @@ namespace App\Services\Storage;
 
 use App\Models\FileDisk;
 use App\Models\Setting;
-use App\Services\Storage\FileDiskService;
 use Spatie\Backup\BackupDestination\BackupDestination;
 
 class BackupService

--- a/composer.json
+++ b/composer.json
@@ -68,8 +68,7 @@
             "@php artisan package:discover --ansi"
         ],
         "post-update-cmd": [
-            "@php artisan vendor:publish --tag=laravel-assets --ansi --force",
-            "@php artisan boost:update --ansi"
+            "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
         ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "gotenberg/gotenberg-php": "^2.8",
         "guzzlehttp/guzzle": "^7.9",
         "hashids/hashids": "^5.0",
-        "invoiceshelf/modules": "^3.0.2",
+        "invoiceshelf/modules": "^3.0.3",
         "laravel/framework": "^13.0",
         "laravel/helpers": "^1.7",
         "laravel/sanctum": "^4.0",
@@ -116,5 +116,11 @@
         }
     },
     "minimum-stability": "stable",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "repositories": {
+        "invoiceshelf-modules": {
+            "type": "vcs",
+            "url": "https://github.com/InvoiceShelf/modules.git"
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "gotenberg/gotenberg-php": "^2.8",
         "guzzlehttp/guzzle": "^7.9",
         "hashids/hashids": "^5.0",
-        "invoiceshelf/modules": "^3.0",
+        "invoiceshelf/modules": "^3.0.2",
         "laravel/framework": "^13.0",
         "laravel/helpers": "^1.7",
         "laravel/sanctum": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df856db1b42a7e244e298e6c129c2cba",
+    "content-hash": "659b80573deb9348366d2000e3bfc81b",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1730,16 +1730,16 @@
         },
         {
             "name": "invoiceshelf/modules",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/InvoiceShelf/modules.git",
-                "reference": "f8184d400cdeb1bcc2ea5e6ed926f4e7b8433570"
+                "reference": "1c39b0234798c65579784e2259b45fa44a264716"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/InvoiceShelf/modules/zipball/f8184d400cdeb1bcc2ea5e6ed926f4e7b8433570",
-                "reference": "f8184d400cdeb1bcc2ea5e6ed926f4e7b8433570",
+                "url": "https://api.github.com/repos/InvoiceShelf/modules/zipball/1c39b0234798c65579784e2259b45fa44a264716",
+                "reference": "1c39b0234798c65579784e2259b45fa44a264716",
                 "shasum": ""
             },
             "require": {
@@ -1775,9 +1775,9 @@
                 "modules"
             ],
             "support": {
-                "source": "https://github.com/InvoiceShelf/modules/tree/3.0.1"
+                "source": "https://github.com/InvoiceShelf/modules/tree/3.0.2"
             },
-            "time": "2026-04-08T22:07:27+00:00"
+            "time": "2026-04-11T10:51:51+00:00"
         },
         {
             "name": "laravel/framework",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "659b80573deb9348366d2000e3bfc81b",
+    "content-hash": "bc1914fedd271f614d922d716ab0e3be",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1730,16 +1730,16 @@
         },
         {
             "name": "invoiceshelf/modules",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/InvoiceShelf/modules.git",
-                "reference": "1c39b0234798c65579784e2259b45fa44a264716"
+                "reference": "9e508914ca64839ef1a1c7d749cc677342dae648"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/InvoiceShelf/modules/zipball/1c39b0234798c65579784e2259b45fa44a264716",
-                "reference": "1c39b0234798c65579784e2259b45fa44a264716",
+                "url": "https://api.github.com/repos/InvoiceShelf/modules/zipball/9e508914ca64839ef1a1c7d749cc677342dae648",
+                "reference": "9e508914ca64839ef1a1c7d749cc677342dae648",
                 "shasum": ""
             },
             "require": {
@@ -1764,7 +1764,19 @@
                     "InvoiceShelf\\Modules\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "InvoiceShelf\\Modules\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "vendor/bin/phpunit"
+                ],
+                "lint": [
+                    "vendor/bin/pint"
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -1775,9 +1787,10 @@
                 "modules"
             ],
             "support": {
-                "source": "https://github.com/InvoiceShelf/modules/tree/3.0.2"
+                "source": "https://github.com/InvoiceShelf/modules/tree/3.0.3",
+                "issues": "https://github.com/InvoiceShelf/modules/issues"
             },
-            "time": "2026-04-11T10:51:51+00:00"
+            "time": "2026-06-05T00:06:47+00:00"
         },
         {
             "name": "laravel/framework",

--- a/storage/app/.gitignore
+++ b/storage/app/.gitignore
@@ -2,3 +2,4 @@
 !public/
 !templates/
 !.gitignore
+!modules_statuses.json

--- a/storage/app/modules_statuses.json
+++ b/storage/app/modules_statuses.json
@@ -1,0 +1,3 @@
+{
+    "HelloWorld": true
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,17 +3,5 @@
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-// The Modules/HelloWorld integration test needs the module enabled at the
-// nwidart level, which is read from storage/app/modules_statuses.json when the
-// app boots. That file is gitignored (created locally by `module:make`), so it
-// is absent in CI and fresh clones — leaving HelloWorld disabled and the
-// integration test failing with 404s. Provision it (only if missing) before any
-// test boots the application, so CI matches a local dev environment.
-$modulesStatuses = __DIR__.'/../storage/app/modules_statuses.json';
-if (! is_file($modulesStatuses)) {
-    @mkdir(dirname($modulesStatuses), 0755, true);
-    file_put_contents($modulesStatuses, json_encode(['HelloWorld' => true], JSON_PRETTY_PRINT).PHP_EOL);
-}
-
 uses(TestCase::class, RefreshDatabase::class)->in('Feature');
 uses(TestCase::class, RefreshDatabase::class)->in('Unit');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,5 +3,17 @@
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
+// The Modules/HelloWorld integration test needs the module enabled at the
+// nwidart level, which is read from storage/app/modules_statuses.json when the
+// app boots. That file is gitignored (created locally by `module:make`), so it
+// is absent in CI and fresh clones — leaving HelloWorld disabled and the
+// integration test failing with 404s. Provision it (only if missing) before any
+// test boots the application, so CI matches a local dev environment.
+$modulesStatuses = __DIR__.'/../storage/app/modules_statuses.json';
+if (! is_file($modulesStatuses)) {
+    @mkdir(dirname($modulesStatuses), 0755, true);
+    file_put_contents($modulesStatuses, json_encode(['HelloWorld' => true], JSON_PRETTY_PRINT).PHP_EOL);
+}
+
 uses(TestCase::class, RefreshDatabase::class)->in('Feature');
 uses(TestCase::class, RefreshDatabase::class)->in('Unit');


### PR DESCRIPTION
Fixes app boot + the AI driver registration on the v3 (`3.x`) line, which failed on any clean `composer install` (CI, Docker, fresh clone) with `Call to undefined method InvoiceShelf\Modules\Registry::register{ExchangeRate,Ai}Driver()`.

### Root cause
The host app calls `Registry::registerExchangeRateDriver()` and `Registry::registerAiDriver()`, but the `invoiceshelf/modules` versions the app resolved didn't include them — `registerAiDriver` shipped only in **3.0.3**.

### What this PR does
1. **`invoiceshelf/modules` → `^3.0.3`.** 3.0.3 adds `registerAiDriver()` (and has `registerExchangeRateDriver()`).
2. **Pull it via a composer VCS repository** pointing at `github.com/InvoiceShelf/modules`, because the package is currently **frozen on Packagist** (Packagist-side stale state — the repo is public, reachable, and the `3.0.3` tag exists). composer reads the Git tag directly, so the app is unblocked regardless of Packagist.
3. **`DriverRegistryProvider`** uses `Registry::registerAiDriver(...)` (the intended API, matching `AiDriverFactoryTest` and the package's provider stub). Net-identical to `3.x` — an earlier temporary `registerDriver('ai', …)` workaround was reverted once 3.0.3 was available.
4. Drive-by: fixed two **pre-existing Pint violations** in `BackupService.php` / `BackupConfigurationFactory.php` that blocked `pint --test` for any PHP-touching PR.

### Verified
`php artisan package:discover` boots clean; the AI suite (incl. the previously-failing `AiDriverFactoryTest`) passes; `pint --test` passes.

> Follow-up (not blocking): un-freeze `invoiceshelf/modules` on Packagist so it can be consumed normally, then the VCS `repositories` entry can be dropped in favour of the plain `^3.0.3` constraint.
