### PR TITLE
fix(documents): preserve edited line-item description

### DIFF
--- a/app/Http/Requests/RecurringInvoiceRequest.php
+++ b/app/Http/Requests/RecurringInvoiceRequest.php
@@ -82,6 +82,9 @@ class RecurringInvoiceRequest extends FormRequest
             'items.*' => [
                 'required',
             ],
+            'items.*.description' => [
+                'nullable',
+            ],
         ];
 
         $customer = Customer::find($this->customer_id);

--- a/resources/scripts/features/shared/document-form/DocumentItemRow.vue
+++ b/resources/scripts/features/shared/document-form/DocumentItemRow.vue
@@ -33,6 +33,7 @@
                   :store="store"
                   @search="searchVal"
                   @select="onSelectItem"
+                  @update:description="updateItemAttribute('description', $event)"
                 />
               </div>
             </td>


### PR DESCRIPTION
## Summary

Fixes a bug where a **line item's description was not preserved** when saving invoices, estimates, or recurring invoices. The per-line description typed into the item textarea never reached the form store, so it was dropped on submit (and a catalog item's description would revert on the next re-render).

## Root cause

All three document types share one row component, so a single dropped event broke them all:

- `resources/scripts/components/base/BaseItemSelect.vue` — the description field's setter **only `emit('update:description', …)`**; it never mutates the item object.
- `resources/scripts/features/shared/document-form/DocumentItemRow.vue` — this shared row (used by invoices, estimates, and recurring invoices via `DocumentItemsTable.vue`) wired `@search` and `@select` but **not** `@update:description`, so the emitted value was discarded and `form.items[index].description` never updated. Every other field (name/quantity/price/discount) had a path back to the store; description was the only orphan.

The backend was correct all along — it persists and returns `description` (schema `TEXT nullable`, item models `$guarded = ['id']`, services pass raw `$request->items` through, resources include `description`). This was purely a dropped frontend event.

## The fix

```vue
@update:description="updateItemAttribute('description', $event)"
```

One line in `DocumentItemRow.vue`, routing the event through the existing `updateItemAttribute` store updater — the same pattern the other fields already use. One fix covers all three document types.

Also adds the missing `items.*.description` nullable rule to `RecurringInvoiceRequest.php` for parity with the invoice/estimate requests (consistency only — not the cause, since recurring persists from raw `$request->items`).

## Verification (manual)

For invoice, estimate, and recurring invoice:
1. Add a line item, type a description **without** selecting a catalog item → Save → reopen → description persists (was lost before).
2. Select a catalog item with a description, edit it per-line → Save → reopen → the edited text sticks.
3. Edit an existing document's item description → Save → reopen → change is kept.
4. Empty description still saves fine (nullable).

ESLint + Pint clean; `npm run build` succeeds. No frontend test harness exists (the `test` script is ESLint-only), so this is verified manually; existing PHP feature tests stay green.
