### PR TITLE
fix(security): block ORDER BY SQL injection via orderByField (GHSA-cp8p)

### DIFF
--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Notifications\CustomerMailResetPasswordNotification;
+use App\Support\SafeOrderBy;
 use App\Traits\HasCustomFieldsTrait;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -161,7 +162,7 @@ class Customer extends Authenticatable implements HasMedia
 
     public function scopeWhereOrder($query, $orderByField, $orderBy)
     {
-        $query->orderBy($orderByField, $orderBy);
+        SafeOrderBy::apply($query, $orderByField, $orderBy);
     }
 
     public function scopeWhereSearch($query, $search)

--- a/app/Models/Estimate.php
+++ b/app/Models/Estimate.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Services\Document\EstimateService;
 use App\Support\Pdf\PdfHtmlSanitizer;
 use App\Support\Pdf\PdfTemplateUtils;
+use App\Support\SafeOrderBy;
 use App\Traits\GeneratesPdfTrait;
 use App\Traits\HasCustomFieldsTrait;
 use Carbon\Carbon;
@@ -191,7 +192,7 @@ class Estimate extends Model implements HasMedia
 
     public function scopeWhereOrder($query, $orderByField, $orderBy)
     {
-        $query->orderBy($orderByField, $orderBy);
+        SafeOrderBy::apply($query, $orderByField, $orderBy);
     }
 
     public function scopeWhereCompany($query)

--- a/app/Models/Expense.php
+++ b/app/Models/Expense.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Support\SafeOrderBy;
 use App\Traits\HasCustomFieldsTrait;
 use Carbon\Carbon;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
@@ -212,7 +213,7 @@ class Expense extends Model implements HasMedia
 
     public function scopeWhereOrder(Builder $query, string $orderByField, string $orderBy): void
     {
-        $query->orderBy($orderByField, $orderBy);
+        SafeOrderBy::apply($query, $orderByField, $orderBy);
     }
 
     public function scopeWhereCompany(Builder $query): void

--- a/app/Models/FileDisk.php
+++ b/app/Models/FileDisk.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Services\Storage\FileDiskService;
+use App\Support\SafeOrderBy;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -49,7 +50,7 @@ class FileDisk extends Model
 
     public function scopeWhereOrder($query, $orderByField, $orderBy)
     {
-        $query->orderBy($orderByField, $orderBy);
+        SafeOrderBy::apply($query, $orderByField, $orderBy);
     }
 
     public function scopeFileDisksBetween($query, $start, $end)

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Services\Document\InvoiceService;
 use App\Support\Pdf\PdfHtmlSanitizer;
 use App\Support\Pdf\PdfTemplateUtils;
+use App\Support\SafeOrderBy;
 use App\Traits\GeneratesPdfTrait;
 use App\Traits\HasCustomFieldsTrait;
 use Carbon\Carbon;
@@ -257,7 +258,7 @@ class Invoice extends Model implements HasMedia
 
     public function scopeWhereOrder($query, $orderByField, $orderBy)
     {
-        $query->orderBy($orderByField, $orderBy);
+        SafeOrderBy::apply($query, $orderByField, $orderBy);
     }
 
     public function scopeApplyFilters($query, array $filters)
@@ -286,7 +287,8 @@ class Invoice extends Model implements HasMedia
             $query->where('customer_id', $customerId);
         })->when($filters['orderByField'] ?? null, function ($query, $orderByField) use ($filters) {
             $orderBy = $filters['orderBy'] ?? 'desc';
-            $query->orderBy($orderByField, $orderBy);
+
+            SafeOrderBy::apply($query, $orderByField, $orderBy);
         }, function ($query) {
             $query->orderBy('sequence_number', 'desc');
         });

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Support\SafeOrderBy;
 use Carbon\Carbon;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
@@ -65,7 +66,7 @@ class Item extends Model
 
     public function scopeWhereOrder(Builder $query, string $orderByField, string $orderBy): void
     {
-        $query->orderBy($orderByField, $orderBy);
+        SafeOrderBy::apply($query, $orderByField, $orderBy);
     }
 
     public function scopeWhereItem(Builder $query, int $item_id): void

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Jobs\GeneratePaymentPdfJob;
 use App\Services\Document\PaymentService;
 use App\Support\Pdf\PdfHtmlSanitizer;
+use App\Support\SafeOrderBy;
 use App\Traits\GeneratesPdfTrait;
 use App\Traits\HasCustomFieldsTrait;
 use Carbon\Carbon;
@@ -194,7 +195,7 @@ class Payment extends Model implements HasMedia
 
     public function scopeWhereOrder($query, $orderByField, $orderBy)
     {
-        $query->orderBy($orderByField, $orderBy);
+        SafeOrderBy::apply($query, $orderByField, $orderBy);
     }
 
     public function scopeWherePayment($query, $payment_id)

--- a/app/Models/RecurringInvoice.php
+++ b/app/Models/RecurringInvoice.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Support\SafeOrderBy;
 use App\Traits\HasCustomFieldsTrait;
 use Carbon\Carbon;
 use Cron;
@@ -129,7 +130,7 @@ class RecurringInvoice extends Model
 
     public function scopeWhereOrder($query, $orderByField, $orderBy)
     {
-        $query->orderBy($orderByField, $orderBy);
+        SafeOrderBy::apply($query, $orderByField, $orderBy);
     }
 
     public function scopeWhereStatus($query, $status)

--- a/app/Models/TaxType.php
+++ b/app/Models/TaxType.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Support\SafeOrderBy;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -76,7 +77,7 @@ class TaxType extends Model
 
     public function scopeWhereOrder(Builder $query, string $orderByField, string $orderBy): void
     {
-        $query->orderBy($orderByField, $orderBy);
+        SafeOrderBy::apply($query, $orderByField, $orderBy);
     }
 
     public function scopeWhereSearch(Builder $query, string $search): void

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Notifications\MailResetPasswordNotification;
+use App\Support\SafeOrderBy;
 use App\Traits\HasCustomFieldsTrait;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -194,7 +195,7 @@ class User extends Authenticatable implements HasMedia
 
     public function scopeWhereOrder($query, $orderByField, $orderBy)
     {
-        $query->orderBy($orderByField, $orderBy);
+        SafeOrderBy::apply($query, $orderByField, $orderBy);
     }
 
     public function scopeWhereSearch($query, $search)

--- a/app/Support/SafeOrderBy.php
+++ b/app/Support/SafeOrderBy.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Support;
+
+class SafeOrderBy
+{
+    /**
+     * Apply a safe ORDER BY clause.
+     *
+     * The orderByField / orderBy values originate from user-supplied query
+     * parameters and were previously passed straight into Eloquent's orderBy(),
+     * allowing arbitrary SQL expressions in the ORDER BY clause (boolean-based
+     * blind injection). Only a plain, optionally table-qualified column
+     * identifier is accepted as the sort target; anything containing SQL syntax
+     * (parentheses, whitespace, sub-selects, ...) falls back to a safe default.
+     * The direction is clamped to asc/desc. Column aliases such as a joined
+     * "customers.name" remain valid, so legitimate sorts are unaffected.
+     */
+    public static function apply($query, $orderByField, $orderBy = 'desc', string $default = 'created_at')
+    {
+        $direction = strtolower((string) $orderBy) === 'asc' ? 'asc' : 'desc';
+
+        $field = is_string($orderByField) ? $orderByField : '';
+
+        if (! preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $field)) {
+            $field = $default;
+        }
+
+        return $query->orderBy($field, $direction);
+    }
+}

--- a/tests/Unit/SafeOrderByTest.php
+++ b/tests/Unit/SafeOrderByTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Support\SafeOrderBy;
+use Illuminate\Support\Facades\DB;
+
+test('rejects sql expressions in the order-by field', function () {
+    $sql = strtolower(
+        SafeOrderBy::apply(DB::table('invoices'), '(CASE WHEN (SELECT 1)=1 THEN id ELSE total END)', 'asc')->toSql()
+    );
+
+    expect($sql)->toContain('order by')
+        ->and($sql)->not->toContain('case')
+        ->and($sql)->not->toContain('select 1');
+});
+
+test('allows a plain column', function () {
+    $sql = strtolower(SafeOrderBy::apply(DB::table('invoices'), 'invoice_date', 'asc')->toSql());
+
+    expect($sql)->toContain('order by')->and($sql)->toContain('invoice_date');
+});
+
+test('allows a table-qualified column so joined/aliased sorts keep working', function () {
+    $sql = strtolower(SafeOrderBy::apply(DB::table('estimates'), 'customers.name', 'asc')->toSql());
+
+    expect($sql)->toContain('customers')->and($sql)->toContain('name');
+});
+
+test('clamps the direction to asc/desc', function () {
+    $sql = strtolower(SafeOrderBy::apply(DB::table('invoices'), 'id', 'asc); drop table users; --')->toSql());
+
+    expect($sql)->toContain('order by')->and($sql)->not->toContain('drop table');
+});


### PR DESCRIPTION
v3 mirror of the v2 fix (#663). Adds `App\Support\SafeOrderBy` (strict column validation + direction clamp) and routes every model's `scopeWhereOrder` through it. Note: v3 scopes are `: void`-typed, so SafeOrderBy is applied without `return`.

v3 is still alpha and is not being released yet; this lands the fix on 3.x so the shared advisory can be published alongside the 2.4.0 (v2) release. Fixes GHSA-cp8p.