### PR TITLE
fix(security): block SSRF via the Gotenberg host setting (GHSA-mfxg)

### DIFF
--- a/app/Http/Requests/PDFConfigurationRequest.php
+++ b/app/Http/Requests/PDFConfigurationRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Rules\PublicHttpUrl;
 use Illuminate\Foundation\Http\FormRequest;
 
 class PDFConfigurationRequest extends FormRequest
@@ -37,6 +38,7 @@ class PDFConfigurationRequest extends FormRequest
                     'gotenberg_host' => [
                         'required',
                         'url',
+                        new PublicHttpUrl,
                     ],
                     'gotenberg_papersize' => [
                         'required',

--- a/app/Support/Pdf/GotenbergPdfDriver.php
+++ b/app/Support/Pdf/GotenbergPdfDriver.php
@@ -2,6 +2,8 @@
 
 namespace App\Support\Pdf;
 
+use App\Support\Net\BlockedUrlException;
+use App\Support\Net\PrivateNetworkGuard;
 use Gotenberg\Gotenberg;
 use Gotenberg\Stream;
 
@@ -15,6 +17,16 @@ class GotenbergPdfDriver
         }
 
         $host = config('pdf.connections.gotenberg.host');
+
+        // SSRF guard: gotenberg_host is an admin-supplied URL the server POSTs
+        // the rendered HTML to. Block private/reserved/link-local targets even
+        // if set via env/seed/stale config or reachable through DNS rebinding.
+        try {
+            PrivateNetworkGuard::assertAllowed((string) $host);
+        } catch (BlockedUrlException $e) {
+            throw new \InvalidArgumentException('Invalid Gotenberg host: '.$e->getMessage());
+        }
+
         $request = Gotenberg::chromium($host)
             ->pdf()
             ->margins(0, 0, 0, 0)

--- a/tests/Unit/GotenbergHostValidationTest.php
+++ b/tests/Unit/GotenbergHostValidationTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Http\Requests\PDFConfigurationRequest;
+use Illuminate\Support\Facades\Validator;
+
+test('gotenberg host rejects private, loopback and link-local addresses', function (string $url) {
+    $rules = PDFConfigurationRequest::create('/', 'POST', ['pdf_driver' => 'gotenberg'])->rules();
+
+    $validator = Validator::make(['gotenberg_host' => $url], ['gotenberg_host' => $rules['gotenberg_host']]);
+
+    expect($validator->fails())->toBeTrue();
+})->with([
+    'http://127.0.0.1',
+    'http://169.254.169.254',
+    'http://10.0.0.5',
+    'http://192.168.1.1',
+]);
+
+test('gotenberg host allows a public address', function () {
+    $rules = PDFConfigurationRequest::create('/', 'POST', ['pdf_driver' => 'gotenberg'])->rules();
+
+    $validator = Validator::make(['gotenberg_host' => 'http://8.8.8.8'], ['gotenberg_host' => $rules['gotenberg_host']]);
+
+    expect($validator->errors()->has('gotenberg_host'))->toBeFalse();
+});


### PR DESCRIPTION
v3 mirror of the v2 fix (#664). Blocks SSRF via the admin-configurable Gotenberg host by reusing v3's existing `App\Rules\PublicHttpUrl` + `PrivateNetworkGuard::assertAllowed` and wiring them into the PDF-configuration request + Gotenberg driver.

v3 is still alpha and is not being released yet; this lands the fix on 3.x so the shared advisory can be published alongside the 2.4.0 (v2) release. Fixes GHSA-mfxg.