### PR TITLE
docs: add Supported Versions policy to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,15 @@
 # Security Policy
 
+## Supported Versions
+
+| Version | Status |
+| ------- | ------ |
+| 3.x | **Active development** — new features and fixes |
+| 2.x | **Security patches only** (feature freeze since 2.4.0) — through **2027-09-01** |
+| ≤ 2.3.x | No longer supported — please update to the latest 2.x or move to 3.x |
+
+As of **2.4.0**, the 2.x line is in feature freeze: all new feature development happens on **3.x**. The 2.x branch will continue to receive **security patches only, until September 1, 2027 (2027-09-01)**. To stay covered, run the latest 2.x release, and plan your upgrade to 3.x ahead of that date.
+
 ## Reporting a Vulnerability
 
 Please email **security@invoiceshelf.com** to report any security vulnerabilities. In the unlikely event that you haven’t heard back, try reaching out on Discord to one of our moderators.


### PR DESCRIPTION
Adds a **Supported Versions** section to `SECURITY.md` reflecting the 2.x feature freeze announced in 2.4.0:

- **3.x** — active development
- **2.x** — security patches only (feature freeze since 2.4.0), through **2027-09-01**
- **≤ 2.3.x** — no longer supported

`make dist` ships `SECURITY.md` in the release zip, so merging this before publishing 2.4.0 keeps the in-package policy accurate. Docs-only change.