### PR TITLE
ci: bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,10 +21,10 @@ jobs:
             php: ${{ steps.filter.outputs.php }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Check for file changes
-              uses: dorny/paths-filter@v3
+              uses: dorny/paths-filter@v4
               id: filter
               with:
                   filters: |
@@ -45,7 +45,7 @@ jobs:
         if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
         steps:
             - name: Cancel Previous Runs
-              uses: styfle/cancel-workflow-action@0.12.1
+              uses: styfle/cancel-workflow-action@0.13.1
               with:
                   access_token: ${{ github.token }}
 
@@ -63,7 +63,7 @@ jobs:
                   php-version: 8.4
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Install dependencies
               uses: ramsey/composer-install@v2
@@ -87,7 +87,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -101,10 +101,10 @@ jobs:
               uses: ramsey/composer-install@v2
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
 
             - name: Use Node.js 24
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24
                   cache: pnpm

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,7 +25,7 @@ jobs:
           php-version: 8.4
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         uses: ramsey/composer-install@v2
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
@@ -62,10 +62,10 @@ jobs:
         uses: ramsey/composer-install@v2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -105,10 +105,10 @@ jobs:
           composer-options: --no-dev
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -140,20 +140,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: invoiceshelf/invoiceshelf
           tags: |
@@ -163,7 +163,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/production/Dockerfile
@@ -180,19 +180,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/production/Dockerfile
@@ -211,7 +211,7 @@ jobs:
         branch: [2.x, develop]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 2
@@ -230,11 +230,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.changes.outputs.has_changes == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
         if: steps.changes.outputs.has_changes == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -251,7 +251,7 @@ jobs:
 
       - name: Build and push Docker image
         if: steps.changes.outputs.has_changes == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/production/Dockerfile


### PR DESCRIPTION
GitHub removes Node 20 from Actions runners on **2026-09-16** (forced to Node 24 on 2026-06-16). Bumps every deprecated action so 2.x CI keeps working through its security-support window (until 2027-09-01).

- checkout v4→v6, setup-node v4→v6, paths-filter v3→v4, cancel-workflow-action 0.12.1→0.13.1, pnpm/action-setup v4→v6
- docker/{setup-buildx v3→v4, login v3→v4, metadata v5→v6, build-push v5→v7}

Left as-is (already node24 / not Node-based): `shivammathur/setup-php@v2`, `ramsey/composer-install@v2` (composite), `svenstaro/upload-release-action@v2`. Pure version bumps in `check.yaml` + `docker.yaml`.