### PR TITLE
ci: bump ramsey/composer-install to 4.0.0 (last Node-20 action)

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -66,7 +66,7 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Install dependencies
-              uses: ramsey/composer-install@v2
+              uses: ramsey/composer-install@4.0.0
 
             - name: Check source code for syntax errors
               run: ./vendor/bin/pint --test
@@ -98,7 +98,7 @@ jobs:
                   tools: pecl, composer
 
             - name: Install Composer dependencies
-              uses: ramsey/composer-install@v2
+              uses: ramsey/composer-install@4.0.0
 
             - name: Install pnpm
               uses: pnpm/action-setup@v6

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@4.0.0
 
       - name: Check source code for syntax errors
         run: ./vendor/bin/pint --test
@@ -59,7 +59,7 @@ jobs:
           tools: pecl, composer
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@4.0.0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -100,7 +100,7 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@4.0.0
         with:
           composer-options: --no-dev
 


### PR DESCRIPTION
Follow-up to #676. `ramsey/composer-install@v2` is a composite action but internally calls `actions/cache@v3` (Node 20) — the last Node-20 deprecation left on 2.x CI after #676. `composer-install@4.0.0` uses `actions/cache@v5.0.3` (Node 24) and keeps the `composer-options` input we use.

(On 3.x this rode in with #657; on 2.x #676 was merged before this commit existed, so it needs its own small PR.)