### PR TITLE
fix(migrations): align ai_conversations company_id/user_id with the INT pk

### DIFF
--- a/database/migrations/2026_04_11_154445_create_ai_conversations_and_messages_tables.php
+++ b/database/migrations/2026_04_11_154445_create_ai_conversations_and_messages_tables.php
@@ -10,8 +10,8 @@ return new class extends Migration
     {
         Schema::create('ai_conversations', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('company_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('company_id');
+            $table->unsignedInteger('user_id');
             $table->string('title')->nullable();
             $table->string('model', 100)->nullable();
             $table->timestamps();


### PR DESCRIPTION
Follow-up to #618. That PR fixed the BIGINT-vs-INT FK mismatch in `impersonation_logs` and `company_invitations`, but the `ai_conversations` table (added 3 days later) has the same issue: `company_id` and `user_id` used `foreignId()` (BIGINT UNSIGNED) while `users.id`/`companies.id` are `increments()` (INT UNSIGNED) — MySQL 8 rejects the FK (error 3780), breaking the v2→v3 upgrade on MySQL.

Switched both to plain `unsignedInteger`, matching the codebase convention (these columns aren't DB-level FKs elsewhere either). `conversation_id` is left as `foreignId()->constrained()` — it references the BIGINT `ai_conversations.id` (no mismatch) and its `cascadeOnDelete` is intentional and covered by `AiChatFlowTest`.