### PR TITLE
ci: auto-register published release on the website updater (v3)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -124,6 +124,42 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
 
+      # Auto-register this release on the website updater backend so deployed installs
+      # are offered it. The zip is already built here (./InvoiceShelf.zip) and the checkout
+      # is present for config/installer.php, so this needs no re-download and can't race the
+      # asset upload. Idempotent per version (the endpoint upserts). Release fields are passed
+      # via env (not inline ${{ }}) to avoid shell injection from the release body.
+      - name: Register release on the website updater
+        env:
+          CI_RELEASE_TOKEN: ${{ secrets.WEBSITE_RELEASE_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
+          PUBLISHED: ${{ github.event.release.published_at }}
+          BODY: ${{ github.event.release.body }}
+        run: |
+          if [ -z "$CI_RELEASE_TOKEN" ]; then
+            echo "::warning::WEBSITE_RELEASE_TOKEN not set — skipping updater registration for $TAG"
+            exit 0
+          fi
+          MIN_PHP=$(php -r '$c=require "config/installer.php"; echo $c["core"]["minPhpVersion"] ?? "";')
+          EXTS=$(php -r '$c=require "config/installer.php"; echo implode(", ", $c["requirements"]["php"] ?? []);')
+          printf '%s' "$BODY" > /tmp/changelog.txt
+          case "$TAG" in
+            *-*) CHANNEL=insider ;;
+            *)   [ "$PRERELEASE" = "true" ] && CHANNEL=insider || CHANNEL=stable ;;
+          esac
+          echo "Registering $TAG (channel=$CHANNEL, min_php=$MIN_PHP) on the updater"
+          curl -fsS --retry 3 --retry-delay 5 -X POST https://invoiceshelf.com/api/releases \
+            -H "Authorization: Bearer $CI_RELEASE_TOKEN" \
+            -F "version=$TAG" \
+            -F "channel=$CHANNEL" \
+            -F "released_at=$PUBLISHED" \
+            -F "min_php_version=$MIN_PHP" \
+            -F "extensions=$EXTS" \
+            -F "changelog=<changelog.txt" \
+            -F "description=<changelog.txt" \
+            -F "release_file=@InvoiceShelf.zip"
+
   release_docker_build:
     name: 🐳 Release Docker Build
     if: github.event_name == 'release'


### PR DESCRIPTION
## What

Appends a **Register release on the website updater** step to the `release_artifact_build` job. When a GitHub release is published, right after `InvoiceShelf.zip` is built and uploaded, CI POSTs it + metadata to the website updater's `POST /api/releases` endpoint — so deployed installs are offered the release **automatically**, instead of the manual `kubectl exec … php artisan tinker import-release.php` flow.

## Details

- Runs only on `release` events (the job already gates on that). The zip is already at `./InvoiceShelf.zip` and the checkout is present, so it needs no re-download and can't race the asset upload.
- **Channel** derived from the pre-release flag / `-` tag suffix (GA→`stable`, alpha/beta/rc→`insider`).
- `min_php_version` + `extensions` read from `config/installer.php`; all release fields passed via `env:` (not inline `${{ }}`) to avoid shell injection from the release body.
- **Idempotent** — the endpoint upserts per version.
- Safe rollout: if `WEBSITE_RELEASE_TOKEN` is unset, the step warns and skips (releases don't break).

## Requires

- Repo secret **`WEBSITE_RELEASE_TOKEN`** (must equal the website's `CI_RELEASE_TOKEN`).
- The website endpoint (InvoiceShelf/website#17) deployed.

Companion PR for the v2 line targets `2.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tpgisKcrC4D4mCbGTeTKz