### PR TITLE
ci: auto-register published release on the website updater (v2)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -136,6 +136,42 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
 
+      # Auto-register this release on the website updater backend so deployed installs
+      # are offered it. The zip is already built here (./InvoiceShelf.zip) and the checkout
+      # is present for config/installer.php, so this needs no re-download and can't race the
+      # asset upload. Idempotent per version (the endpoint upserts). Release fields are passed
+      # via env (not inline ${{ }}) to avoid shell injection from the release body.
+      - name: Register release on the website updater
+        env:
+          CI_RELEASE_TOKEN: ${{ secrets.WEBSITE_RELEASE_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
+          PUBLISHED: ${{ github.event.release.published_at }}
+          BODY: ${{ github.event.release.body }}
+        run: |
+          if [ -z "$CI_RELEASE_TOKEN" ]; then
+            echo "::warning::WEBSITE_RELEASE_TOKEN not set — skipping updater registration for $TAG"
+            exit 0
+          fi
+          MIN_PHP=$(php -r '$c=require "config/installer.php"; echo $c["core"]["minPhpVersion"] ?? "";')
+          EXTS=$(php -r '$c=require "config/installer.php"; echo implode(", ", $c["requirements"]["php"] ?? []);')
+          printf '%s' "$BODY" > /tmp/changelog.txt
+          case "$TAG" in
+            *-*) CHANNEL=insider ;;
+            *)   [ "$PRERELEASE" = "true" ] && CHANNEL=insider || CHANNEL=stable ;;
+          esac
+          echo "Registering $TAG (channel=$CHANNEL, min_php=$MIN_PHP) on the updater"
+          curl -fsS --retry 3 --retry-delay 5 -X POST https://invoiceshelf.com/api/releases \
+            -H "Authorization: Bearer $CI_RELEASE_TOKEN" \
+            -F "version=$TAG" \
+            -F "channel=$CHANNEL" \
+            -F "released_at=$PUBLISHED" \
+            -F "min_php_version=$MIN_PHP" \
+            -F "extensions=$EXTS" \
+            -F "changelog=<changelog.txt" \
+            -F "description=<changelog.txt" \
+            -F "release_file=@InvoiceShelf.zip"
+
   release_docker_build:
     name: 🐳 Release Docker Build
     if: github.event_name == 'release'


### PR DESCRIPTION
## What

v2 (`2.x`) companion to #693. Appends a **Register release on the website updater** step to the `release_artifact_build` job: after `InvoiceShelf.zip` is built and uploaded on a published release, CI POSTs it + metadata to the website updater's `POST /api/releases` endpoint, so deployed v2 installs are offered the release **automatically** instead of the manual `kubectl exec … tinker import-release.php` flow.

## Details

- Runs only on `release` events; zip is already built in-job (no re-download, no asset-timing race).
- **Channel** from the pre-release flag / `-` tag suffix (GA→`stable`, pre→`insider`).
- `min_php_version` + `extensions` read from this branch's `config/installer.php` (so v2's own requirements are used); fields passed via `env:` to avoid shell injection.
- **Idempotent** (endpoint upserts per version); skips with a warning if `WEBSITE_RELEASE_TOKEN` is unset.

## Requires

- Repo secret **`WEBSITE_RELEASE_TOKEN`** (shared with #693; must equal the website's `CI_RELEASE_TOKEN`).
- Website endpoint (InvoiceShelf/website#17) deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tpgisKcrC4D4mCbGTeTKz