### PR TITLE
fix: update ImageUtils namespace in PDF blade templates

### DIFF
--- a/resources/views/app/pdf/estimate/estimate1.blade.php
+++ b/resources/views/app/pdf/estimate/estimate1.blade.php
@@ -396,7 +396,7 @@
             <tr>
                 <td class="text-center">
                     @if ($logo)
-                        <img class="header-logo" style="height:50px" src="{{ \App\Services\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
+                        <img class="header-logo" style="height:50px" src="{{ \App\Support\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
                     @else
                         @if ($estimate->customer->company)
                             <h2 class="header-logo"> {{ $estimate->customer->company->name }} </h2>

--- a/resources/views/app/pdf/estimate/estimate2.blade.php
+++ b/resources/views/app/pdf/estimate/estimate2.blade.php
@@ -417,7 +417,7 @@
             <tr>
                 @if ($logo)
                     <td width="60%" class="header-section-left">
-                        <img class="header-logo" style="height:50px" src="{{ \App\Services\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
+                        <img class="header-logo" style="height:50px" src="{{ \App\Support\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
                     </td>
                 @else
                     <td width="60%" class="header-section-left" style="padding-top: 0px;">

--- a/resources/views/app/pdf/estimate/estimate3.blade.php
+++ b/resources/views/app/pdf/estimate/estimate3.blade.php
@@ -356,7 +356,7 @@
             <tr>
                 <td width="50%" class="header-section-left">
                     @if ($logo)
-                        <img class="header-logo" style="height:50px" src="{{ \App\Services\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
+                        <img class="header-logo" style="height:50px" src="{{ \App\Support\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
                     @else
                         <h1 class="header-logo"> {{ $estimate->customer->company->name }} </h1>
                     @endif

--- a/resources/views/app/pdf/invoice/invoice1.blade.php
+++ b/resources/views/app/pdf/invoice/invoice1.blade.php
@@ -338,7 +338,7 @@
             <tr>
                 <td class="text-center">
                     @if ($logo)
-                        <img class="header-logo" style="height:50px" src="{{ \App\Services\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
+                        <img class="header-logo" style="height:50px" src="{{ \App\Support\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
                     @else
                         @if ($invoice->customer->company)
                             <h2 class="header-logo"> {{ $invoice->customer->company->name }}</h2>

--- a/resources/views/app/pdf/invoice/invoice2.blade.php
+++ b/resources/views/app/pdf/invoice/invoice2.blade.php
@@ -388,7 +388,7 @@
             <tr>
                 <td width="60%" class="header-section-left">
                     @if ($logo)
-                        <img class="header-logo" style="height:50px" src="{{ \App\Services\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
+                        <img class="header-logo" style="height:50px" src="{{ \App\Support\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
                     @elseif ($invoice->customer->company)
                         <h1 class="header-logo" style="padding-top: 0px;">
                             {{ $invoice->customer->company->name }}

--- a/resources/views/app/pdf/invoice/invoice3.blade.php
+++ b/resources/views/app/pdf/invoice/invoice3.blade.php
@@ -317,7 +317,7 @@
             <tr>
                 <td width="50%" class="header-section-left">
                     @if ($logo)
-                        <img class="header-logo" style="height:50px" src="{{ \App\Services\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
+                        <img class="header-logo" style="height:50px" src="{{ \App\Support\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
                     @else
                         <h1 class="header-logo"> {{ $invoice->customer->company->name }} </h1>
                     @endif

--- a/resources/views/app/pdf/payment/payment.blade.php
+++ b/resources/views/app/pdf/payment/payment.blade.php
@@ -286,7 +286,7 @@
             <tr>
                 @if ($logo)
                     <td width="50%" class="header-section-left">
-                        <img style="height:50px" class="header-logo" src="{{ \App\Services\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
+                        <img style="height:50px" class="header-logo" src="{{ \App\Support\Pdf\ImageUtils::toBase64Src($logo) }}" alt="Company Logo">
                     @else
                         @if ($payment->customer)
                     <td class="header-section-left" style="padding-top:0px;">


### PR DESCRIPTION
The `ImageUtils` class was moved from `App\Services\Pdf` to `App\Support\Pdf` but the blade templates were not updated to reflect this change.

This causes `Class App\Services\Pdf\ImageUtils not found` errors when generating PDFs for invoices, estimates, and payments.

This PR updates the namespace in the 7 blade template files.