### PR TITLE
test(pdf): cover every stock PDF template, and silence the PHP 8.5 PDO deprecation

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -1,6 +1,16 @@
 <?php
 
 use Illuminate\Support\Str;
+use Pdo\Mysql;
+
+// PHP 8.5 deprecated PDO::MYSQL_ATTR_SSL_CA in favour of Pdo\Mysql::ATTR_SSL_CA,
+// which does not exist before 8.5. This package supports ^8.4, so resolve
+// whichever name the running version provides — both refer to the same
+// attribute. Kept behind the extension check because neither constant is
+// defined at all when pdo_mysql is missing.
+$mysqlSslCaAttribute = extension_loaded('pdo_mysql')
+    ? (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA)
+    : null;
 
 return [
 
@@ -58,8 +68,8 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            'options' => $mysqlSslCaAttribute !== null ? array_filter([
+                $mysqlSslCaAttribute => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -78,8 +88,8 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            'options' => $mysqlSslCaAttribute !== null ? array_filter([
+                $mysqlSslCaAttribute => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/storage/framework/.gitignore
+++ b/storage/framework/.gitignore
@@ -6,3 +6,4 @@ services.json
 events.scanned.php
 routes.scanned.php
 down
+testing/

--- a/tests/Feature/Pdf/PdfTemplateRenderTest.php
+++ b/tests/Feature/Pdf/PdfTemplateRenderTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Models\Estimate;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\User;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Testing\TestResponse;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\get;
+
+/**
+ * Renders every stock PDF template end-to-end through the real pdf routes.
+ *
+ * These templates are Blade, so class references inside them (e.g.
+ * ImageUtils::toBase64Src) are plain strings — invisible to IDE renames, to
+ * Pint, and to every other check in CI. A move like #695's leaves the app fatal
+ * on any company with a logo, and nothing catches it until a user generates an
+ * invoice. Rendering each template here is the only thing that does.
+ *
+ * The template list is read off disk rather than hardcoded so a newly added
+ * template is covered the moment it lands.
+ */
+function stockPdfTemplates(string $type): array
+{
+    // Datasets are resolved before the application is booted, so this cannot
+    // use resource_path() or the File facade — plain glob only. The *.blade.php
+    // pattern also keeps the partials/ subdirectory out of the list.
+    $files = glob(dirname(__DIR__, 3)."/resources/views/app/pdf/{$type}/*.blade.php");
+
+    return array_values(array_map(
+        fn ($path) => basename($path, '.blade.php'),
+        $files ?: []
+    ));
+}
+
+/**
+ * Asserts the route returned a PDF.
+ *
+ * Presence, not position: the body currently carries the status line and
+ * headers of an inner Response ahead of the PDF payload, because
+ * GeneratesPdfTrait wraps $pdf->stream() — already a Response — in another
+ * response()->make(). Readers tolerate leading bytes before %PDF, which is why
+ * nobody has noticed. Asserting presence keeps this test honest about what it
+ * covers (the render not fatalling) without baking the malformed prefix in as
+ * expected output.
+ */
+function assertRenderedPdf(TestResponse $response): void
+{
+    $response->assertOk();
+
+    expect($response->headers->get('content-type'))->toContain('application/pdf');
+    expect(substr($response->getContent(), 0, 1024))->toContain('%PDF');
+}
+
+dataset('invoice templates', fn () => stockPdfTemplates('invoice'));
+dataset('estimate templates', fn () => stockPdfTemplates('estimate'));
+
+beforeEach(function () {
+    Artisan::call('db:seed', ['--class' => 'DatabaseSeeder', '--force' => true]);
+    Artisan::call('db:seed', ['--class' => 'DemoSeeder', '--force' => true]);
+
+    $user = User::find(1);
+    $this->company = $user->companies()->first();
+
+    Sanctum::actingAs($user, ['*']);
+
+    // The logo collection lives on the `public` disk. Fake it so the run never
+    // writes into (or clears) a developer's real storage/app/public — media ids
+    // restart at 1 under RefreshDatabase and would otherwise collide with
+    // whatever is already sitting there.
+    Storage::fake('public');
+
+    // Every template guards the logo behind `@if ($logo)` and falls back to the
+    // company name, so without a logo attached the ImageUtils branch is never
+    // reached and this suite would pass against the broken code.
+    $this->company
+        ->addMediaFromString(base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+        ))
+        ->usingFileName('logo.png')
+        ->toMediaCollection('logo');
+});
+
+test('every stock invoice template renders a pdf with a company logo', function (string $template) {
+    $invoice = Invoice::factory()
+        ->hasItems(1)
+        ->create([
+            'company_id' => $this->company->id,
+            'template_name' => $template,
+        ]);
+
+    assertRenderedPdf(get("/invoices/pdf/{$invoice->unique_hash}"));
+})->with('invoice templates');
+
+test('every stock estimate template renders a pdf with a company logo', function (string $template) {
+    $estimate = Estimate::factory()
+        ->hasItems(1)
+        ->create([
+            'company_id' => $this->company->id,
+            'template_name' => $template,
+        ]);
+
+    assertRenderedPdf(get("/estimates/pdf/{$estimate->unique_hash}"));
+})->with('estimate templates');
+
+test('the payment template renders a pdf with a company logo', function () {
+    $payment = Payment::factory()->create([
+        'company_id' => $this->company->id,
+    ]);
+
+    assertRenderedPdf(get("/payments/pdf/{$payment->unique_hash}"));
+});
+
+/**
+ * The assertions above prove the pipeline does not fatal. This one proves the
+ * logo actually reached the markup as a base64 data URI — i.e. that
+ * ImageUtils::toBase64Src resolved and ran, which is the specific regression
+ * #695 fixed. Without it, a template that silently dropped the logo would still
+ * emit a valid PDF and pass.
+ */
+test('the rendered invoice markup embeds the logo as a base64 data uri', function (string $template) {
+    $invoice = Invoice::factory()
+        ->hasItems(1)
+        ->create([
+            'company_id' => $this->company->id,
+            'template_name' => $template,
+        ]);
+
+    get("/invoices/pdf/{$invoice->unique_hash}?preview=true")
+        ->assertOk()
+        ->assertSee('src="data:image/png;base64,', false);
+})->with('invoice templates');


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

Follow-up to #695. That fix was correct, but nothing in the repo would have caught the bug and nothing would catch the next one: there was no test touching the PDF render path at all, and Pint is the only static gate — a dangling class reference inside a Blade string is invisible to both. The regression shipped in `6d1816bd` and sat on `3.x` for three months, fatal for any company with a logo uploaded.

**`tests/Feature/Pdf/PdfTemplateRenderTest.php`** — 10 tests, 27 assertions

- Renders every stock invoice, estimate and payment template end-to-end through the real `/invoices/pdf/{hash}` routes.
- **With a company logo attached.** Every template guards the logo behind `@if ($logo)` and falls back to the company name, so without one the ImageUtils branch is never reached and this suite would have passed against the broken code.
- Template names are globbed off disk rather than hardcoded, so a newly added stock template is covered as soon as it lands.
- One assertion checks the rendered markup actually carries `src="data:image/png;base64,`, so a template that silently *drops* the logo fails too rather than emitting a valid but logo-less PDF.
- `Storage::fake('public')` keeps the run out of the developer's real `storage/app/public` (media ids restart at 1 under `RefreshDatabase` and would otherwise collide with whatever is already there). It is paratest-safe — Laravel appends `_test_{token}` per worker — and verified under `--parallel`, which is how CI runs.

Verified the tests actually fail on the bug they exist for: reverting `invoice2.blade.php` to the pre-#695 namespace turns exactly the two tests touching that template red, with `Class "App\Services\Pdf\ImageUtils" not found in .../invoice2.blade.php:391`.

**`config/database.php`** — resolve `PDO::MYSQL_ATTR_SSL_CA` per PHP version

PHP 8.5 deprecated it in favour of `Pdo\Mysql::ATTR_SSL_CA`, which meant every test in the suite was reported as `deprecated` rather than `passed` — noise that would hide a real deprecation. `Pdo\Mysql` doesn't exist before 8.5 and this package supports `^8.4`, so the constant is resolved at runtime; the untaken ternary branch is never looked up, which keeps 8.4 working.

Checked against both runtimes, since the constant's numeric value legitimately differs: with `MYSQL_ATTR_SSL_CA` set, 8.4 resolves to attribute `1009` and 8.5 to `1008` — each version's own value, matching what the previous code produced there.

**`storage/framework/.gitignore`** — ignore `testing/`, the fake-disk root created by the new tests.

## Test plan

- `php artisan test` → **510 passed** (1229 assertions). Previously 510 *deprecated*.
- `php artisan test --parallel` (as CI runs) → 510 passed, no cross-worker flakiness.
- `vendor/bin/pint --test` → clean.

## Backwards compatibility

No application code changes. The `config/database.php` change preserves the resolved attribute value on both supported PHP versions.

## Noticed while writing this, not fixed here

Two pre-existing bugs found by rendering these paths for the first time. Both deserve their own PR, so neither is touched here:

1. **PDFs are served with HTTP headers prepended.** `GeneratesPdfTrait::getGeneratedPDFOrStream()` wraps `$pdf->stream()` in `response()->make()`, but `stream()` already returns a `Response` (`barryvdh/laravel-dompdf/src/PDF.php:227`). Stringifying it puts `HTTP/1.0 200 OK\r\nContent-Type: application/pdf...` ahead of `%PDF` in the body. Readers scan the first 1KB for the header so it renders fine, but the output is malformed and strict parsers / PDF-A validators will reject it — relevant to #688, which wants Gotenberg specifically for PDF/A. The test asserts `%PDF` is *present* in the first 1KB rather than at offset 0, with a comment explaining why, so it doesn't bless the bug as expected output.

2. **`/payments/pdf/{hash}?preview` is broken.** `DocumentPdfController::payment()` returns `view('app.pdf.payment.payment')` without the `view()->share()` that `PaymentService::getPdfData()` performs, so `$logo` and `$payment` are undefined. Invoice and estimate previews go through their services and are fine. Left uncovered rather than committing a red test.

## Issues

- follows #695