### PR TITLE
fix(ui): stop depending on secure-context APIs over plain HTTP

### DIFF
--- a/resources/scripts/features/company/payments/components/PaymentDropdown.vue
+++ b/resources/scripts/features/company/payments/components/PaymentDropdown.vue
@@ -136,14 +136,25 @@ function removePayment(): void {
 function copyPdfUrl(): void {
   const payment = props.row as Payment
   const pdfUrl = `${window.location.origin}/payments/pdf/${payment.unique_hash}`
-  navigator.clipboard.writeText(pdfUrl).catch(() => {
-    const textarea = document.createElement('textarea')
-    textarea.value = pdfUrl
-    document.body.appendChild(textarea)
-    textarea.select()
-    document.execCommand('copy')
-    document.body.removeChild(textarea)
-  })
+
+  // navigator.clipboard is [SecureContext]-gated, so on a plain-HTTP origin it is
+  // undefined and `.writeText` throws on property access — before any promise
+  // exists for .catch() to handle. Test up front, as the invoice and estimate
+  // dropdowns already do.
+  if (navigator.clipboard && window.isSecureContext) {
+    navigator.clipboard.writeText(pdfUrl)
+    return
+  }
+
+  const textarea = document.createElement('textarea')
+  textarea.value = pdfUrl
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.focus()
+  textarea.select()
+  document.execCommand('copy')
+  document.body.removeChild(textarea)
 }
 
 function sendPayment(): void {

--- a/resources/scripts/utils/generate-client-id.ts
+++ b/resources/scripts/utils/generate-client-id.ts
@@ -1,3 +1,17 @@
+let counter = 0
+
+/**
+ * Local identity for a row that does not exist server-side yet — a new invoice
+ * item, a new tax line. The server assigns the real numeric id on save (hence
+ * `id: number | string` on DocumentItem/DocumentTax), so this only has to stay
+ * unique within the page session, which a counter guarantees outright.
+ *
+ * Deliberately not `crypto.randomUUID()`: that is `[SecureContext]`-gated, so it
+ * is undefined on any plain-HTTP origin that isn't localhost. That covers the
+ * dev host (`http://invoiceshelf.test`) and self-hosted installs reached over a
+ * hostname or LAN IP — where calling it threw during Pinia store construction
+ * and took the document screens down with it. Nothing here needs randomness.
+ */
 export function generateClientId(): string {
-  return crypto.randomUUID()
+  return `client-${++counter}`
 }


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

`crypto.randomUUID()` and `navigator.clipboard` are both `[SecureContext]`-gated, so neither exists on a plain-HTTP origin that isn't `localhost`. That covers the dev host (`http://invoiceshelf.test`) and any self-hosted install reached over a hostname or LAN IP — `http://invoiceshelf.local`, `http://192.168.1.50`, `http://nas:8080`. Given the audience is self-hosters, that is not a narrow slice.

- **`resources/scripts/utils/generate-client-id.ts`** — called `crypto.randomUUID()` unguarded. It runs during Pinia store construction via the invoice, estimate and recurring-invoice stub factories, so on those origins it threw `TypeError: crypto.randomUUID is not a function` before the store existed and took the document screens down with it.

  The value is only a placeholder identity for a row that has no server id yet — the server assigns the real one on save, which is why `DocumentItem`/`DocumentTax` type it `number | string`. It never needed randomness, so it is now a session counter: no crypto, no fallback branch, no conditional, works everywhere.

- **`PaymentDropdown.copyPdfUrl()`** — had a textarea fallback attached via `.catch()`, which can never fire: on a non-secure origin `navigator.clipboard` is `undefined`, so `.writeText` throws on property access before any promise exists. "Copy PDF URL" was therefore broken on payments in the same environments. Now tests up front, matching the guard `InvoiceDropdown.vue:275` and `EstimateDropdown.vue:302` already use.

## Test plan

- `pnpm lint` clean; `pnpm build` clean.
- `grep randomUUID public/build/assets/*.js` → no matches after the build.
- Reproduced the original `TypeError` on `http://invoiceshelf.test`, confirmed gone after rebuild.

## Backwards compatibility

`generateClientId()` returned a string before and returns a string now, and `id` is already typed `number | string`. Nothing parses or compares these values — the only consumers are stub factories and Vue list keys.

## Notes

- **No test.** `"test"` in `package.json` is just ESLint — there is no vitest/jest, so a regression here cannot be caught automatically. Standing up a JS test runner felt like its own decision rather than something to fold into a bug fix.
- The textarea-fallback helper now exists in near-identical form in three dropdowns. Worth extracting to `resources/scripts/utils/`, left out to keep this focused.

## Issues

- fixes #