### PR TITLE
fix(seeder): assign unique_hash to seeded documents

### DIFF
--- a/database/seeders/RealisticDemoSeeder.php
+++ b/database/seeders/RealisticDemoSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Facades\Hashids;
 use App\Models\Address;
 use App\Models\AiConversation;
 use App\Models\CompanySetting;
@@ -452,6 +453,10 @@ class RealisticDemoSeeder extends Seeder
 
         // Touch timestamps to match the invoice_date so tool queries like
         // `latest('invoice_date')` match `latest('created_at')` plausibly.
+        // The PDF routes bind on unique_hash. Creating through the model rather
+        // than InvoiceService skips the one place that normally assigns it, so
+        // set it here or every seeded document 404s on preview and download.
+        $invoice->unique_hash = Hashids::connection(Invoice::class)->encode($invoice->id);
         $invoice->created_at = $invoiceDate;
         $invoice->updated_at = $invoiceDate;
         $invoice->save();
@@ -515,6 +520,8 @@ class RealisticDemoSeeder extends Seeder
             'notes' => null,
         ]);
 
+        // See seedInvoice(): the PDF routes bind on unique_hash.
+        $payment->unique_hash = Hashids::connection(Payment::class)->encode($payment->id);
         $payment->created_at = $paymentDate;
         $payment->updated_at = $paymentDate;
         $payment->save();
@@ -585,6 +592,8 @@ class RealisticDemoSeeder extends Seeder
             'notes' => null,
         ]);
 
+        // See seedInvoice(): the PDF routes bind on unique_hash.
+        $estimate->unique_hash = Hashids::connection(Estimate::class)->encode($estimate->id);
         $estimate->created_at = $estimateDate;
         $estimate->updated_at = $estimateDate;
         $estimate->save();

--- a/tests/Feature/Admin/RealisticDemoSeederTest.php
+++ b/tests/Feature/Admin/RealisticDemoSeederTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Models\Estimate;
+use App\Models\Invoice;
+use App\Models\Payment;
+use Illuminate\Support\Facades\Artisan;
+
+beforeEach(function () {
+    Artisan::call('db:seed', ['--class' => 'DatabaseSeeder', '--force' => true]);
+    Artisan::call('db:seed', ['--class' => 'RealisticDemoSeeder', '--force' => true]);
+});
+
+/**
+ * The PDF routes bind on unique_hash (`/invoices/pdf/{invoice:unique_hash}`), and
+ * the seeder builds its documents with Model::create() rather than through the
+ * service layer that normally assigns it. When that was missed, every seeded
+ * document produced a `/invoices/pdf/` URL with an empty segment — a 404, surfaced
+ * in the UI only as "Unable to load document preview", with nothing in the log.
+ *
+ * Anything the seeder creates that the app then serves by hash has to carry one.
+ */
+test('every seeded document has the unique hash its pdf route binds on', function (string $model) {
+    expect($model::count())->toBeGreaterThan(0);
+
+    expect($model::whereNull('unique_hash')->orWhere('unique_hash', '')->count())
+        ->toBe(0);
+})->with([
+    Invoice::class,
+    Estimate::class,
+    Payment::class,
+]);


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

`RealisticDemoSeeder` builds invoices, payments and estimates with `Model::create()` (lines 418, 502, 561), which bypasses **both** paths that normally assign `unique_hash`:

- the factories set it directly (`InvoiceFactory` → `str_random(60)`)
- `InvoiceService` / `PaymentService` / `EstimateService` encode it from the id after insert

Nothing assigned it in the seeder, so every seeded document had `unique_hash` NULL.

The PDF routes bind on that column (`/invoices/pdf/{invoice:unique_hash}`), so `InvoiceDetailView.vue:313` built `/invoices/pdf/` with an empty segment. That 404s, and the only symptom is **"Unable to load document preview"** in the UI — nothing reaches `laravel.log`, because a route-model-binding miss isn't an application error. It took a trip through the nginx access log to find. Anyone who seeds realistic demo data and opens a document hits this.

- Sets `unique_hash` on all three, alongside the existing timestamp assignment so there's no extra write.
- Uses `Hashids` as the services do, rather than the factories' `str_random`, so demo data matches what the app itself would produce.
- Adds `tests/Feature/Admin/RealisticDemoSeederTest.php`, which runs the seeder and asserts no document is missing the hash its PDF route binds on.

## Test plan

- `php artisan test tests/Feature/Admin/RealisticDemoSeederTest.php` → 3 passed, ~1s.
- Commenting out the invoice assignment fails it with `Failed asserting that 35 is identical to 0`, so it catches the regression it exists for.
- Full suite: 503 passed. `vendor/bin/pint --test` clean.

## Backwards compatibility

**Production is unaffected** — documents created through the app go through the service layer, which already assigns the hash. This only ever affected seeded demo data.

Databases already seeded still hold NULLs and need a one-off backfill, encoding each id the same way the services do:

```php
use App\Facades\Hashids;

foreach ([Invoice::class, Estimate::class, Payment::class] as $model) {
    foreach ($model::whereNull('unique_hash')->get() as $row) {
        $row->unique_hash = Hashids::connection($model)->encode($row->id);
        $row->save();
    }
}
```

## Noticed, not fixed here

`InvoiceDetailView.vue:313` falls back to `?? ''` when the hash is missing, which silently builds a URL that cannot work and fires a fetch at it (three times, via `BasePdfPreview`'s retry). Not rendering the preview at all would have surfaced the cause immediately instead of a generic failure. Left alone because this PR removes the condition that triggers it, and changing it means deciding what the empty state should render — worth its own change if you want the defence in depth.

## Issues

- fixes #