### PR TITLE
feat(devenv): make the Gotenberg compose stacks work out of the box

### DIFF
--- a/devenv
+++ b/devenv
@@ -508,6 +508,12 @@ setup_environment() {
     if [ "$use_gotenberg" = "yes" ]; then
         compose_file="docker/development/docker-compose.${db_type}.gotenberg.yml"
         print_success "Using Gotenberg-enabled compose file"
+        # The compose file sets PDF_DRIVER, GOTENBERG_HOST and
+        # GOTENBERG_ALLOWED_PRIVATE_HOST on the php-fpm service, so the sidecar
+        # works with no .env editing. Say so, because the last one exists to let
+        # a private host past the SSRF guard and that is worth knowing about.
+        print_info "PDF driver preconfigured: gotenberg via http://pdf:3000" >&2
+        print_info "The compose file exempts that host from the SSRF guard (GOTENBERG_ALLOWED_PRIVATE_HOST)." >&2
     else
         compose_file="docker/development/docker-compose.${db_type}.yml"
         print_success "Using standard compose file"

--- a/docker/development/docker-compose.mysql.gotenberg.yml
+++ b/docker/development/docker-compose.mysql.gotenberg.yml
@@ -8,6 +8,13 @@ services:
         - UID=${USRID:-1000}
         - GID=${GRPID:-1000}
       target: development
+    environment:
+      # Gotenberg runs as the `pdf` service below, on this compose network, so
+      # its host resolves to a private address. PrivateNetworkGuard rejects those
+      # by default — naming the exact host is what exempts it, and only it.
+      - PDF_DRIVER=gotenberg
+      - GOTENBERG_HOST=http://pdf:3000
+      - GOTENBERG_ALLOWED_PRIVATE_HOST=http://pdf:3000
     volumes:
       - ../../:/var/www/html
     networks:

--- a/docker/development/docker-compose.pgsql.gotenberg.yml
+++ b/docker/development/docker-compose.pgsql.gotenberg.yml
@@ -8,6 +8,13 @@ services:
         - UID=${USRID:-1000}
         - GID=${GRPID:-1000}
       target: development
+    environment:
+      # Gotenberg runs as the `pdf` service below, on this compose network, so
+      # its host resolves to a private address. PrivateNetworkGuard rejects those
+      # by default — naming the exact host is what exempts it, and only it.
+      - PDF_DRIVER=gotenberg
+      - GOTENBERG_HOST=http://pdf:3000
+      - GOTENBERG_ALLOWED_PRIVATE_HOST=http://pdf:3000
     volumes:
       - ../../:/var/www/html
     networks:

--- a/docker/development/docker-compose.sqlite.gotenberg.yml
+++ b/docker/development/docker-compose.sqlite.gotenberg.yml
@@ -8,6 +8,13 @@ services:
         - UID=${USRID:-1000}
         - GID=${GRPID:-1000}
       target: development
+    environment:
+      # Gotenberg runs as the `pdf` service below, on this compose network, so
+      # its host resolves to a private address. PrivateNetworkGuard rejects those
+      # by default — naming the exact host is what exempts it, and only it.
+      - PDF_DRIVER=gotenberg
+      - GOTENBERG_HOST=http://pdf:3000
+      - GOTENBERG_ALLOWED_PRIVATE_HOST=http://pdf:3000
     volumes:
       - ../../:/var/www/html
     networks:


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

Follow-up to #691. Answering "yes" to *"Use Gotenberg for PDF generation?"* in `./devenv` started the `pdf` sidecar and configured nothing else — the app still defaulted to `dompdf`. Pointing it at the sidecar by hand then hit the SSRF guard, because `pdf` resolves to a private address (`172.22.0.6`) on the compose network. That is #688, reproduced from inside our own dev environment.

- The three `docker/development/docker-compose.{sqlite,pgsql,mysql}.gotenberg.yml` files now set `PDF_DRIVER`, `GOTENBERG_HOST` and `GOTENBERG_ALLOWED_PRIVATE_HOST` on the `php-fpm` service. The service is already named `pdf`, matching the shipped config default, so no rename was needed.
- `devenv` prints what it configured, including that the compose file exempts that one host from the SSRF guard — a security control being relaxed shouldn't be silent.

### Why compose env rather than writing `.env`

The plan for this was originally to have `devenv` write the keys into `.env`. Compose is the better home:

- `devenv` does not touch `.env` today, and adding file mutation brings append-vs-update and clobbering questions for no benefit here.
- The values belong to the compose file the developer explicitly selected — they are scoped to the Gotenberg variants and disappear if you switch back.
- Non-Docker setups already have the same keys documented in `.env.example` (added in #691).

`clear_env = no` is set in the serversideup pool config (`docker-php-serversideup-pool.conf:86`), so these do reach the php-fpm workers — that is worth stating because the default for php-fpm is to strip them.

## Test plan

Verified on a live stack rather than by inspection:

- `docker compose config -q` passes on all three files.
- After recreating `php-fpm`: `printenv` shows all three vars, and `env('PDF_DRIVER')` returns `gotenberg` from PHP. `PDF_DRIVER` is deliberately not in my `.env`, so that is unambiguous proof the compose environment is the source.
- End to end: `Invoice::find(1)->getPDFData()` rendered a real **24967-byte** document starting `%PDF-1.4` through the sidecar, with no `.env` editing anywhere.
- `bash -n devenv` clean.

## Backwards compatibility

No application code changes; nothing outside `docker/development/` and the `devenv` script. Only affects developers who pick Gotenberg. The non-Gotenberg compose files are untouched, and an existing `.env` still wins for anything it sets that the compose file doesn't.

## Not in scope

- A Gotenberg variant for `docker/production/`, or for the upstream `InvoiceShelf/docker` repo (neither has one) — that is a distribution decision worth raising separately.
- Documentation: the `docs/` repo has no Gotenberg coverage at all. That is a separate PR in that repo.
- A connectivity test for the configured host. Saving an unreachable host currently succeeds with no warning and only fails later at PDF generation — `PrivateNetworkGuard` deliberately fails open on hostnames that don't resolve. A `POST /pdf/test` mirroring the existing `/ai/test` would close that, but it needs a route, controller, policy and UI button, so it is its own change.

## Issues

- follows #691