### PR TITLE
fix(gotenberg): allow a declared private host past the SSRF guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,14 @@ TRUSTED_PROXIES="*"
 # Dompdf: keep false so untrusted HTML in PDF notes cannot trigger outbound requests (SSRF).
 # Set true only if you fully trust all PDF HTML and need remote images/CSS.
 DOMPDF_ENABLE_REMOTE=false
+
+# Gotenberg (optional alternative PDF driver; the default is dompdf).
+# PDF_DRIVER=gotenberg
+# GOTENBERG_HOST=http://pdf:3000
+# GOTENBERG_PAPERSIZE="210mm 297mm"
+#
+# Gotenberg is normally a sidecar on a private network, which the SSRF guard
+# rejects. Name that one host to exempt it — and only it. Every other private
+# target stays blocked, so the host cannot later be repointed at an internal
+# service. Leave unset unless you actually run Gotenberg privately.
+# GOTENBERG_ALLOWED_PRIVATE_HOST=http://pdf:3000

--- a/app/Http/Requests/PDFConfigurationRequest.php
+++ b/app/Http/Requests/PDFConfigurationRequest.php
@@ -3,7 +3,9 @@
 namespace App\Http\Requests;
 
 use App\Rules\SafeRemoteUrl;
+use App\Support\GotenbergHostPolicy;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class PDFConfigurationRequest extends FormRequest
 {
@@ -30,6 +32,12 @@ class PDFConfigurationRequest extends FormRequest
                 ];
 
             case 'gotenberg':
+                // The operator-declared Gotenberg host skips the public-address
+                // check; anything else is still held to it. See GotenbergHostPolicy.
+                $isDeclaredHost = GotenbergHostPolicy::isExemptFromSafeRemoteUrl(
+                    $this->input('gotenberg_host')
+                );
+
                 return [
                     'pdf_driver' => [
                         'required',
@@ -38,7 +46,7 @@ class PDFConfigurationRequest extends FormRequest
                     'gotenberg_host' => [
                         'required',
                         'url',
-                        new SafeRemoteUrl,
+                        Rule::when(! $isDeclaredHost, [new SafeRemoteUrl]),
                     ],
                     'gotenberg_papersize' => [
                         'required',

--- a/app/Services/PDFDrivers/GotenbergPDFDriver.php
+++ b/app/Services/PDFDrivers/GotenbergPDFDriver.php
@@ -3,6 +3,7 @@
 namespace App\Services\PDFDrivers;
 
 use App\Rules\SafeRemoteUrl;
+use App\Support\GotenbergHostPolicy;
 use Gotenberg\Gotenberg;
 use Gotenberg\Stream;
 use Illuminate\Http\Response;
@@ -47,8 +48,12 @@ class GotenbergPDFDriver
 
         // Defense in depth against SSRF: a host that bypassed request-time
         // validation (env/seed/stale config, or DNS rebinding) must still not
-        // be able to target internal/private addresses.
-        if (! SafeRemoteUrl::isSafe((string) $host)) {
+        // be able to target internal/private addresses. The single exception is
+        // the host the operator declared in GOTENBERG_ALLOWED_PRIVATE_HOST,
+        // which is how a sidecar deployment is supported — see
+        // GotenbergHostPolicy.
+        if (! GotenbergHostPolicy::isExemptFromSafeRemoteUrl((string) $host)
+            && ! SafeRemoteUrl::isSafe((string) $host)) {
             throw new \RuntimeException('Refusing to render PDF: unsafe Gotenberg host.');
         }
 

--- a/app/Support/GotenbergHostPolicy.php
+++ b/app/Support/GotenbergHostPolicy.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Support;
+
+use App\Rules\SafeRemoteUrl;
+
+/**
+ * Decides whether a Gotenberg host is exempt from {@see SafeRemoteUrl}.
+ *
+ * Gotenberg is normally deployed as a sidecar on a private network — the shipped
+ * default host is `http://pdf:3000` — which the SSRF guard rejects. The exemption
+ * is declared in the environment and names the single host it trusts:
+ *
+ *     GOTENBERG_ALLOWED_PRIVATE_HOST=http://pdf:3000
+ *
+ * It is deliberately NOT a boolean and deliberately not settable from the admin
+ * UI. `gotenberg_host` itself stays editable, and the driver returns the upstream
+ * response body verbatim as the PDF — so a blanket "allow private" switch would
+ * let that setting be repointed at a link-local metadata endpoint and read back
+ * the response. Matching one declared host keeps the sidecar working while every
+ * other private target stays blocked.
+ *
+ * Both the save-time validation rule and the runtime driver guard call this, so
+ * the two layers cannot drift apart.
+ */
+class GotenbergHostPolicy
+{
+    /**
+     * Whether the given host is the operator-declared Gotenberg host, and may
+     * therefore skip the public-address check.
+     */
+    public static function isExemptFromSafeRemoteUrl(?string $host): bool
+    {
+        $allowed = config('pdf.connections.gotenberg.allowed_private_host');
+
+        if (! is_string($allowed) || ! is_string($host)) {
+            return false;
+        }
+
+        $allowed = self::normalize($allowed);
+        $host = self::normalize($host);
+
+        // An unset or unparseable allowlist never exempts anything.
+        return $allowed !== null && $allowed === $host;
+    }
+
+    /**
+     * Reduce a URL to scheme://host[:port][/path] with casing and any trailing
+     * slash removed, so `HTTP://PDF:3000/` and `http://pdf:3000` compare equal.
+     *
+     * Returns null when the value is empty or carries no scheme and host.
+     */
+    protected static function normalize(string $url): ?string
+    {
+        $url = trim($url);
+
+        if ($url === '') {
+            return null;
+        }
+
+        $parts = parse_url($url);
+
+        if ($parts === false || ! isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        // parse_url keeps IPv6 literals bracketed; strip them on both sides so
+        // the comparison is consistent.
+        $host = strtolower(trim($parts['host'], '[]'));
+
+        if ($host === '') {
+            return null;
+        }
+
+        return sprintf(
+            '%s://%s%s%s',
+            strtolower($parts['scheme']),
+            $host,
+            isset($parts['port']) ? ':'.$parts['port'] : '',
+            rtrim($parts['path'] ?? '', '/'),
+        );
+    }
+}

--- a/config/pdf.php
+++ b/config/pdf.php
@@ -30,6 +30,16 @@ return [
         'gotenberg' => [
             'host' => env('GOTENBERG_HOST', 'http://pdf:3000'),
             'papersize' => env('GOTENBERG_PAPERSIZE', '210mm 297mm'),
+
+            /*
+             * Gotenberg usually runs as a sidecar on a private network, which the
+             * SSRF guard rejects. Name that one host here to exempt it — e.g.
+             * GOTENBERG_ALLOWED_PRIVATE_HOST=http://pdf:3000. Only this exact value
+             * is exempt; the guard still blocks every other private target, so the
+             * host setting cannot be repointed at an internal service. No default:
+             * the `host` fallback above must never be trusted implicitly.
+             */
+            'allowed_private_host' => env('GOTENBERG_ALLOWED_PRIVATE_HOST'),
         ],
     ],
 

--- a/tests/Unit/Rules/GotenbergHostPolicyTest.php
+++ b/tests/Unit/Rules/GotenbergHostPolicyTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Http\Requests\PDFConfigurationRequest;
+use App\Services\PDFDrivers\GotenbergPDFDriver;
+use App\Support\GotenbergHostPolicy;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Build the gotenberg_host rules the way the form request would for a given
+ * submitted host, then validate that host against them.
+ */
+function validateGotenbergHost(string $url): Illuminate\Validation\Validator
+{
+    $rules = PDFConfigurationRequest::create('/', 'POST', [
+        'pdf_driver' => 'gotenberg',
+        'gotenberg_host' => $url,
+    ])->rules();
+
+    return Validator::make(['gotenberg_host' => $url], ['gotenberg_host' => $rules['gotenberg_host']]);
+}
+
+test('a private gotenberg host is rejected when nothing is declared', function (string $url) {
+    config(['pdf.connections.gotenberg.allowed_private_host' => null]);
+
+    expect(validateGotenbergHost($url)->fails())->toBeTrue();
+})->with([
+    'http://127.0.0.1:3000',
+    'http://169.254.169.254',
+    'http://10.0.0.5:3000',
+    'http://192.168.1.1:3000',
+]);
+
+test('the private host declared in the environment is accepted', function () {
+    config(['pdf.connections.gotenberg.allowed_private_host' => 'http://10.0.0.5:3000']);
+
+    expect(validateGotenbergHost('http://10.0.0.5:3000')->errors()->has('gotenberg_host'))->toBeFalse();
+});
+
+/**
+ * The point of naming the host rather than flipping a boolean: declaring one
+ * private host must not open the guard for any other. Without this, an operator
+ * who enables the sidecar also hands an admin the ability to repoint the setting
+ * at a cloud metadata endpoint and read the response back as a "PDF".
+ */
+test('declaring one private host does not exempt any other', function (string $url) {
+    config(['pdf.connections.gotenberg.allowed_private_host' => 'http://pdf:3000']);
+
+    expect(validateGotenbergHost($url)->fails())->toBeTrue();
+})->with([
+    'http://169.254.169.254',
+    'http://127.0.0.1:3000',
+    'http://10.0.0.5:3000',
+]);
+
+test('the declared host is matched ignoring case and trailing slash', function (string $configured, string $submitted) {
+    config(['pdf.connections.gotenberg.allowed_private_host' => $configured]);
+
+    expect(GotenbergHostPolicy::isExemptFromSafeRemoteUrl($submitted))->toBeTrue();
+})->with([
+    ['http://pdf:3000', 'http://pdf:3000/'],
+    ['http://pdf:3000/', 'http://pdf:3000'],
+    ['HTTP://PDF:3000', 'http://pdf:3000'],
+    ['  http://pdf:3000  ', 'http://pdf:3000'],
+]);
+
+test('the policy rejects hosts that differ in any meaningful part', function (string $submitted) {
+    config(['pdf.connections.gotenberg.allowed_private_host' => 'http://pdf:3000']);
+
+    expect(GotenbergHostPolicy::isExemptFromSafeRemoteUrl($submitted))->toBeFalse();
+})->with([
+    'http://pdf:3001',
+    'https://pdf:3000',
+    'http://pdf',
+    'http://other:3000',
+    'http://pdf:3000/render',
+    'not a url',
+    '',
+]);
+
+test('an unset allowlist exempts nothing', function () {
+    config(['pdf.connections.gotenberg.allowed_private_host' => null]);
+
+    expect(GotenbergHostPolicy::isExemptFromSafeRemoteUrl('http://pdf:3000'))->toBeFalse();
+});
+
+/**
+ * The driver guard is the authoritative layer — it re-checks at render time, so
+ * it has to agree with the validation rule. Asserted on the blocking path only:
+ * it throws before any HTTP call is attempted, so the test never touches the
+ * network.
+ */
+test('the driver still blocks a private host that was not declared', function () {
+    config([
+        'pdf.connections.gotenberg.host' => 'http://169.254.169.254',
+        'pdf.connections.gotenberg.papersize' => '210mm 297mm',
+        'pdf.connections.gotenberg.allowed_private_host' => 'http://pdf:3000',
+    ]);
+
+    expect(fn () => (new GotenbergPDFDriver)->loadView('app.pdf.invoice.invoice1'))
+        ->toThrow(RuntimeException::class, 'unsafe Gotenberg host');
+});


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

Backport of #691 to `2.x`. #688's reporter is on **2.4.1**, and the error they quoted — *"The gotenberg host must be a valid, publicly reachable http(s) URL"* — comes from `app/Rules/SafeRemoteUrl.php`, so the 3.x fix does nothing for them.

`SafeRemoteUrl`, added in the 2.4.0 security round, rejects private addresses. That includes `http://pdf:3000` — the shipped default in `config/pdf.php` and the standard Compose sidecar name. **The guard rejects its own default**, so Gotenberg cannot be configured at all on the normal deployment.

`GOTENBERG_ALLOWED_PRIVATE_HOST` names the single host that may skip the check:

```bash
GOTENBERG_ALLOWED_PRIVATE_HOST=http://pdf:3000
```

- `config/pdf.php` — new `allowed_private_host` key, no default (the `host` fallback must never be trusted implicitly).
- `app/Support/GotenbergHostPolicy.php` — owns the exact-match comparison, normalising case, trailing slash and surrounding whitespace.
- `PDFConfigurationRequest` — drops `SafeRemoteUrl` only when the submitted host matches, via `Rule::when()`.
- `GotenbergPDFDriver` — same check before the runtime guard, so the two layers cannot drift.
- `.env.example` — documents all four Gotenberg keys; there were none.

### Why not a boolean, and why not in the UI

The driver streams the upstream response body back as the PDF. A blanket "allow private" switch would leave `gotenberg_host` editable and repointable at a link-local metadata endpoint, with the response read back as a download — so the installs that enabled it for a sidecar would be exactly the ones exposed. Naming one host keeps the sidecar working while every other private target stays blocked. Environment-only, because whoever decides a private host is trustworthy should be whoever controls the network.

### One deliberate difference from 3.x

`SafeRemoteUrl::isSafe()` **rejects** hosts that do not resolve; 3.x's `PrivateNetworkGuard` lets them through as "not provably unsafe". That behaviour is unchanged here, so on 2.x a typo'd host is still refused at save time rather than saving cleanly and failing later at render. That is the friendlier outcome and I saw no reason to align it downward.

## Feature freeze

2.x is security-patches-only until 2027-09. This is in scope as a **regression introduced by a security patch** — it restores a deployment that 2.4.0 broke, and it narrows rather than widens the guard's exemption surface. It adds no features.

## Test plan

- `tests/Unit/Rules/GotenbergHostPolicyTest.php` — 16 cases covering both directions, including the one that proves the design: *declaring one private host does not exempt any other*.
- Sabotaging the policy to always exempt fails **16 of 36** tests in `tests/Unit/Rules/`, so the suite catches the regression it exists for.
- Full suite: **337 passed**. `vendor/bin/pint --test` clean.

## Backwards compatibility

Behaviour is unchanged unless `GOTENBERG_ALLOWED_PRIVATE_HOST` is set. Existing installs see no difference; nothing is removed and no existing validation is relaxed.

## Issues

- fixes #688