### PR TITLE
fix(config): resolve the mysql SSL CA attribute per PHP version

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -1,6 +1,16 @@
 <?php
 
 use Illuminate\Support\Str;
+use Pdo\Mysql;
+
+// PHP 8.5 deprecated PDO::MYSQL_ATTR_SSL_CA in favour of Pdo\Mysql::ATTR_SSL_CA,
+// which does not exist before 8.5. This package supports ^8.4, so resolve
+// whichever name the running version provides — both refer to the same
+// attribute. Kept behind the extension check because neither constant is
+// defined at all when pdo_mysql is missing.
+$mysqlSslCaAttribute = extension_loaded('pdo_mysql')
+    ? (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA)
+    : null;
 
 return [
 
@@ -58,8 +68,8 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            'options' => $mysqlSslCaAttribute !== null ? array_filter([
+                $mysqlSslCaAttribute => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -78,8 +88,8 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            'options' => $mysqlSslCaAttribute !== null ? array_filter([
+                $mysqlSslCaAttribute => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

Port of #696 to `2.x`. PHP 8.5 deprecated `PDO::MYSQL_ATTR_SSL_CA` in favour of `Pdo\Mysql::ATTR_SSL_CA`, so on 8.5 the entire suite reports as **deprecated** rather than **passed** — 316 tests of noise that would bury a real deprecation if one appeared.

`Pdo\Mysql` does not exist before 8.5 and this package supports `^8.4`, so the constant is resolved at runtime. The untaken ternary branch is never looked up, which is what keeps 8.4 working. The lookup stays behind the existing `extension_loaded('pdo_mysql')` check, because neither name is defined at all when the extension is missing.

## Test plan

Checked against both runtimes, since the constant's numeric value legitimately differs between them:

| | resolved attribute |
|---|---|
| PHP 8.4.23 | `1009` |
| PHP 8.5.0 | `1008` |

Each version resolves its own value — the same one the previous code produced there — which is why this is resolved at runtime rather than hardcoded.

- Full suite: **316 passed** (641 assertions). Previously 316 *deprecated*.
- `vendor/bin/pint --test` clean.

## Feature freeze

2.x is security-patches-only until 2027-09, and this is not a security fix — flagging that explicitly rather than filing it under the exception.

The case for taking it anyway: 2.x is supported for another two years, PHP 8.5 is shipping now, and a branch that emits a deprecation on every single test run makes any *real* deprecation invisible for the rest of that support window. It is a two-line compatibility change with no behavioural difference on either supported PHP version. Happy to drop it if you would rather hold the line.

## Backwards compatibility

The resolved attribute value is identical to what the previous code produced on each supported PHP version, verified above. No behavioural change.

## Issues

- follows #696