### PR TITLE
fix(docker): recreate storage directories on container start

### DIFF
--- a/docker/production/entrypoint.d/00-setup.sh
+++ b/docker/production/entrypoint.d/00-setup.sh
@@ -12,6 +12,32 @@ InvoiceShelf Version:  $version
 
 cd /var/www/html
 
+# These carry no tracked content — only .gitignore stubs — so a mount over
+# storage/ can arrive without them, and Laravel then dies at boot with "Please
+# provide a valid cache path" (config/view.php resolves its compiled path with
+# realpath(), which returns false for a missing directory). Recreate them before
+# anything writes there, including the sqlite database placed in storage/app
+# below. See InvoiceShelf/docker#75, #69 and #77.
+echo "**** Ensuring storage directories exist ****"
+if ! mkdir -p \
+    storage/app/public \
+    storage/framework/cache/data \
+    storage/framework/sessions \
+    storage/framework/views \
+    storage/logs \
+    bootstrap/cache 2>/dev/null; then
+    echo "!!!! Cannot write to /var/www/html/storage."
+    echo "!!!! This container runs as uid $(id -u) (www-data), but the mounted"
+    echo "!!!! directory belongs to someone else — usually a bind mount pointing"
+    echo "!!!! at a host directory owned by your own user."
+    echo "!!!! Give that directory to uid 82 on the host and start again:"
+    echo "!!!!"
+    echo "!!!!     sudo chown -R 82:82 /path/to/your/storage"
+    echo "!!!!"
+    echo "!!!! See https://github.com/InvoiceShelf/docker/issues/77"
+    exit 1
+fi
+
 if [ ! -e /var/www/html/.env ]; then
     cp .env.example .env
     echo "**** Setup initial .env values ****" && \
@@ -33,8 +59,16 @@ if [ "$DB_CONNECTION" = "sqlite" ] || [ -z "$DB_CONNECTION" ]; then
     chown www-data:www-data "$DB_DATABASE"
 fi
 
-echo "**** Setting up artisan permissions ****"
+echo "**** Setting up folder permissions ****"
 chmod +x artisan
+
+# Only root may change ownership. The image normally runs as www-data, where
+# this is both impossible and unnecessary — the files it created are already
+# owned correctly — so it is skipped rather than failing the boot on a chown we
+# are not permitted to make. It still helps anyone running the image as root.
+if [ "$(id -u)" = "0" ]; then
+    chown -R www-data:www-data storage bootstrap/cache
+fi
 
 if ! grep -q "APP_KEY" /var/www/html/.env
 then


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

The most-reported problem on the docker tracker. `storage/framework/{cache,sessions,views}`, `storage/logs` and `storage/app` hold no tracked content — only `.gitignore` stubs — so nothing guarantees they exist inside a mounted volume.

**Docker seeds a named volume from the image exactly once, when the volume is empty, and never again.** A volume created by an older image therefore keeps whatever it had through every subsequent upgrade. When those directories are absent, Laravel dies at boot with `Please provide a valid cache path`, because `config/view.php` resolves its compiled path with `realpath()`, which returns `false` for a missing directory. The sqlite branch also cannot place its database.

- `mkdir -p` the required directories at the top of the entrypoint, before anything writes to them — including the sqlite database placed in `storage/app` further down.
- The `chown` is guarded on being root.
- A mount the container genuinely cannot write to now produces a clear message naming the remedy, instead of surfacing later as a Laravel stack trace.

### On the chown guard

This tree previously had an unguarded `chown -R www-data:www-data storage bootstrap/cache`, which 2.x still has. The image runs as **www-data (uid 82)**, and `chown` of a foreign-owned file is `EPERM` for a non-root user — under `set -e` that stops the container from starting at all. That is the likely reason it was dropped here. Guarding on `id -u = 0` keeps the benefit for anyone running the image as root without reintroducing that failure mode.

## Test plan

Verified against a locally built production image, not by inspection.

**The bug, reproduced.** Seed a named volume from the image, delete `storage/framework`, restart with the *current* entrypoint:

```
In Compiler.php line 75:
  Please provide a valid cache path.
```

**The fix.** Same volume, same image, this entrypoint — `php artisan about` runs, and the volume comes back with `framework/{cache,sessions,views}` and `logs` restored.

**Unwritable bind mount.** Current entrypoint fails with `cp: can't create '/var/www/html/storage/app/database.sqlite': No such file or directory` — near-identical to the Synology report on #63. With this change it says what is wrong and what to do, and exits 1 rather than half-starting.

**Clean run.** Container reaches `running`, HTTP 302 from the app.

## Backwards compatibility

`mkdir -p` on directories that already exist is a no-op, so the normal path is unchanged. The chown guard is strictly less likely to fail than an unguarded chown.

## Issues

- fixes InvoiceShelf/docker#75
- fixes InvoiceShelf/docker#69
- addresses InvoiceShelf/docker#77
- addresses InvoiceShelf/docker#63