### PR TITLE
fix(docker): recreate storage directories and guard the chown

### DIFF
--- a/docker/production/entrypoint.d/00-setup.sh
+++ b/docker/production/entrypoint.d/00-setup.sh
@@ -12,6 +12,32 @@ InvoiceShelf Version:  $version
 
 cd /var/www/html
 
+# These carry no tracked content — only .gitignore stubs — so a mount over
+# storage/ can arrive without them, and Laravel then dies at boot with "Please
+# provide a valid cache path" (the compiled view path is resolved with
+# realpath(), which returns false for a missing directory). Recreate them before
+# anything writes there, including the sqlite database placed in storage/app
+# below. See InvoiceShelf/docker#75, #69 and #77.
+echo "**** Ensuring storage directories exist ****"
+if ! mkdir -p \
+    storage/app/public \
+    storage/framework/cache/data \
+    storage/framework/sessions \
+    storage/framework/views \
+    storage/logs \
+    bootstrap/cache 2>/dev/null; then
+    echo "!!!! Cannot write to /var/www/html/storage."
+    echo "!!!! This container runs as uid $(id -u) (www-data), but the mounted"
+    echo "!!!! directory belongs to someone else — usually a bind mount pointing"
+    echo "!!!! at a host directory owned by your own user."
+    echo "!!!! Give that directory to uid 82 on the host and start again:"
+    echo "!!!!"
+    echo "!!!!     sudo chown -R 82:82 /path/to/your/storage"
+    echo "!!!!"
+    echo "!!!! See https://github.com/InvoiceShelf/docker/issues/77"
+    exit 1
+fi
+
 if [ ! -e /var/www/html/.env ]; then
     cp .env.example .env
     echo "**** Setup initial .env values ****" && \
@@ -35,8 +61,16 @@ fi
 
 echo "**** Setting up folder permissions ****"
 chmod +x artisan
-chown -R www-data:www-data storage bootstrap/cache
-chmod -R 775 storage bootstrap/cache
+
+# Only root may change ownership. The image runs as www-data, where chown of a
+# foreign-owned file is EPERM — and under `set -e` that stopped the container
+# from starting at all, on exactly the mounted-volume setups this was meant to
+# help. Skip it there rather than fail the boot; still applied when running as
+# root. See InvoiceShelf/docker#77 and #69.
+if [ "$(id -u)" = "0" ]; then
+    chown -R www-data:www-data storage bootstrap/cache
+    chmod -R 775 storage bootstrap/cache
+fi
 
 if [ ! -L /var/www/html/public/storage ]; then
     echo "**** Creating storage symlink (public/storage) ****"


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

Backport of #702. **The chown half is a 2.x-only fix** — 3.x had already dropped that line.

`storage/framework/{cache,sessions,views}`, `storage/logs` and `storage/app` hold no tracked content, only `.gitignore` stubs, so nothing guarantees they exist inside a mounted volume. Docker seeds a named volume from the image once, when it is empty, and never again — a volume created by an older image keeps whatever it had through every upgrade. Without those directories Laravel cannot boot and the sqlite branch cannot place its database.

**The unguarded `chown -R www-data:www-data storage bootstrap/cache` is worse than ineffective.** The image runs as www-data (uid 82), so `chown` of any file it does not own returns `EPERM`, and under `set -e` that aborts the entrypoint. **A single uploaded file owned by the host user is enough to stop the container from starting** — on exactly the mounted-volume setups the chown was meant to help.

## Test plan

Against a locally built 2.x production image.

**The chown failure, measured.** Storage owned by uid 82 containing one file owned by uid 1000:

```
BEFORE (unguarded chown) exit code: 1
AFTER  (guarded chown)   exit code: 0
```

with `chown: storage/app/user-upload.pdf: Operation not permitted` in the before case.

**Missing directories.** Named volume with `storage/framework` deleted:

```
BEFORE — missing framework/: (no output, boot fails)
AFTER  — missing framework/: Laravel Framework 13.15.0
```

**Unwritable bind mount.** Before: `cp: can't create '/var/www/html/storage/app/database.sqlite': No such file or directory` — near-identical to the Synology report on #63. After: a message naming the remedy, and exit 1 rather than a half-start.

Full suite: **325 passed**.

## Backwards compatibility

`mkdir -p` on existing directories is a no-op. The chown is strictly less likely to fail than before — it now runs only where it can succeed.

## Issues

- fixes InvoiceShelf/docker#75
- fixes InvoiceShelf/docker#69
- addresses InvoiceShelf/docker#77
- addresses InvoiceShelf/docker#63