### PR TITLE
fix(config): make the application timezone configurable

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -6,6 +6,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Timezone
+    |--------------------------------------------------------------------------
+    |
+    | The default timezone for date and date-time functions. Laravel's own
+    | fallback is the literal string 'UTC' rather than an env() lookup, so
+    | without this key APP_TIMEZONE has no effect at all and scheduled tasks
+    | and recurring invoices always run on UTC.
+    |
+    */
+
+    'timezone' => env('APP_TIMEZONE', 'UTC'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Class Aliases
     |--------------------------------------------------------------------------
     |

--- a/docker/production/inject.sh
+++ b/docker/production/inject.sh
@@ -48,8 +48,13 @@ elif [ "$DB_PASSWORD_FILE" != '' ]; then
   value=$(<$DB_PASSWORD_FILE)
    replace_or_insert "DB_PASSWORD" "$value"
 fi
-if [ "$TIMEZONE" != '' ]; then
-   replace_or_insert "TIMEZONE" "$TIMEZONE"
+# Laravel reads APP_TIMEZONE. This previously wrote a bare TIMEZONE key, which
+# nothing consumed, so setting the variable silently did nothing. Accept both
+# names so existing compose files keep working.
+if [ "$APP_TIMEZONE" != '' ]; then
+   replace_or_insert "APP_TIMEZONE" "$APP_TIMEZONE"
+elif [ "$TIMEZONE" != '' ]; then
+   replace_or_insert "APP_TIMEZONE" "$TIMEZONE"
 fi
 if [ "$CACHE_STORE" != '' ]; then
    replace_or_insert "CACHE_STORE" "$CACHE_STORE"


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

Backport of #703. Recurring invoices and scheduled tasks always run on UTC, whatever you configure. Two bugs compound so that **no supported value has any effect**:

1. `config/app.php` has no `timezone` key, so Laravel's own fallback wins — and that fallback is a literal `'UTC'` string, not an `env()` lookup. `APP_TIMEZONE` has therefore been inert despite shipping in `.env.example`.
2. `inject.sh` wrote a bare `TIMEZONE` key into `.env`, which nothing reads — so the documented container variable did nothing either.

`inject.sh` now writes `APP_TIMEZONE` and accepts either spelling, so existing compose files keep working unchanged.

## Test plan

```
default:                    UTC      (before and after)
APP_TIMEZONE=Europe/Berlin: UTC      before
APP_TIMEZONE=Europe/Berlin: Europe/Berlin   after
```

Full suite: **316 passed**. `vendor/bin/pint --test` clean.

## Backwards compatibility

The default stays `UTC`, so instances that never set the variable are unaffected. Anyone who *had* set `TIMEZONE` expecting it to work will find it starts working — the behaviour they asked for, but worth a release-note line since clocks will shift for them.

## Issues

- fixes InvoiceShelf/docker#64