### PR TITLE
fix(installation): support mariadb in the setup wizard

### DIFF
--- a/app/Http/Controllers/V1/Installation/DatabaseConfigurationController.php
+++ b/app/Http/Controllers/V1/Installation/DatabaseConfigurationController.php
@@ -77,6 +77,28 @@ class DatabaseConfigurationController extends Controller
 
                 break;
 
+            case 'mariadb':
+                $databaseData = [
+                    'database_connection' => 'mariadb',
+                    'database_host' => '127.0.0.1',
+                    'database_port' => 3306,
+                ];
+
+                break;
+
+            default:
+                // Never return an empty config: the wizard picks its form from
+                // database_connection, so an unrecognised driver used to render
+                // a blank step with no way forward. Echo it back with the
+                // server defaults instead.
+                $databaseData = [
+                    'database_connection' => $connection,
+                    'database_host' => '127.0.0.1',
+                    'database_port' => 3306,
+                ];
+
+                break;
+
         }
 
         return response()->json([

--- a/resources/scripts/admin/views/installation/Step3DatabaseConfig.vue
+++ b/resources/scripts/admin/views/installation/Step3DatabaseConfig.vue
@@ -28,6 +28,10 @@ export default {
     Mysql,
     Pgsql,
     Sqlite,
+    // Resolved by <component :is="database_connection">. MariaDB takes the same
+    // fields as MySQL, so it reuses that form rather than duplicating it —
+    // without an entry here the step renders blank. See InvoiceShelf/docker#79.
+    Mariadb: Mysql,
   },
 
   emits: ['next'],

--- a/resources/scripts/admin/views/installation/database/MysqlDatabase.vue
+++ b/resources/scripts/admin/views/installation/database/MysqlDatabase.vue
@@ -133,7 +133,7 @@ const props = defineProps({
 
 const emit = defineEmits(['submit-data', 'on-change-driver'])
 
-const connections = reactive(['sqlite', 'mysql', 'pgsql'])
+const connections = reactive(['sqlite', 'mysql', 'mariadb', 'pgsql'])
 const { t } = useI18n()
 const utils = inject('utils')
 

--- a/resources/scripts/admin/views/installation/database/PgsqlDatabase.vue
+++ b/resources/scripts/admin/views/installation/database/PgsqlDatabase.vue
@@ -153,7 +153,7 @@ const props = defineProps({
 
 const emit = defineEmits(['submit-data', 'on-change-driver'])
 
-const connections = reactive(['sqlite', 'mysql', 'pgsql'])
+const connections = reactive(['sqlite', 'mysql', 'mariadb', 'pgsql'])
 const { t } = useI18n()
 const utils = inject('utils')
 

--- a/resources/scripts/admin/views/installation/database/SqliteDatabase.vue
+++ b/resources/scripts/admin/views/installation/database/SqliteDatabase.vue
@@ -97,7 +97,7 @@ const props = defineProps({
 
 const emit = defineEmits(['submit-data', 'on-change-driver'])
 
-const connections = reactive(['sqlite', 'mysql', 'pgsql'])
+const connections = reactive(['sqlite', 'mysql', 'mariadb', 'pgsql'])
 const { t } = useI18n()
 const utils = inject('utils')
 

--- a/tests/Feature/Installation/DatabaseConfigurationTest.php
+++ b/tests/Feature/Installation/DatabaseConfigurationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use function Pest\Laravel\getJson;
+
+/**
+ * The setup wizard picks which form to render from `database_connection` in this
+ * response. When the switch had no arm for the requested driver it returned an
+ * empty config, so step 3 rendered blank with no way to continue and nothing in
+ * the log — the app never errored, it just answered with nothing.
+ *
+ * That is what InvoiceShelf/docker#79 hit: the shipped docker-compose.mysql.yml
+ * sets DB_CONNECTION=mariadb, so a fresh install using the official compose file
+ * could not get past the database step.
+ */
+test('the database config endpoint answers with a usable config for every supported driver', function (string $connection) {
+    $response = getJson("/api/v1/installation/database/config?connection={$connection}");
+
+    $response->assertOk();
+
+    expect($response->json('config.database_connection'))->toBe($connection);
+})->with([
+    'mysql',
+    'mariadb',
+    'pgsql',
+    'sqlite',
+]);
+
+test('sqlite is told where its database file lives', function () {
+    $response = getJson('/api/v1/installation/database/config?connection=sqlite');
+
+    $response->assertOk();
+
+    expect($response->json('config.database_name'))->not->toBeEmpty();
+});
+
+test('server-based drivers are given a host and port to prefill', function (string $connection) {
+    $response = getJson("/api/v1/installation/database/config?connection={$connection}");
+
+    expect($response->json('config.database_host'))->not->toBeEmpty()
+        ->and($response->json('config.database_port'))->not->toBeEmpty();
+})->with([
+    'mysql',
+    'mariadb',
+    'pgsql',
+]);
+
+/**
+ * A driver we do not recognise must still produce something the wizard can
+ * render, rather than the empty config that caused #79.
+ */
+test('an unrecognised driver still returns a renderable config', function () {
+    $response = getJson('/api/v1/installation/database/config?connection=cockroach');
+
+    $response->assertOk();
+
+    expect($response->json('config.database_connection'))->toBe('cockroach')
+        ->and($response->json('config'))->not->toBeEmpty();
+});


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

Backport of #704. A fresh install using the **shipped** `docker-compose.mysql.yml` cannot get past the database step, because that compose file sets `DB_CONNECTION=mariadb`.

`getDatabaseEnvironment()` switched on `sqlite`, `pgsql` and `mysql` with no arm for `mariadb` and no `default`, so it answered `{"config":[]}`. The wizard renders `<component :is="database_connection">`, which resolves to nothing, so the step came out blank — and nothing reached the log, because the app never errored, it just replied with nothing. That silence is why the issue sat unexplained.

- Adds the `mariadb` arm, and a `default` so an unrecognised driver is echoed back with server defaults rather than producing an unrenderable response.
- Registers MariaDB as an alias of the MySQL form — the fields are identical — and offers it in each driver picker.

## Test plan

New `tests/Feature/Installation/DatabaseConfigurationTest.php`, 9 cases across all four drivers plus the unknown-driver path.

Run against the **original** controller, three fail with the reported symptom:

```
Failed asserting that null is identical to 'mariadb'.
Failed asserting that null is identical to 'cockroach'.
```

Full suite: **325 passed**. `pint` clean, `vite build` clean. ESLint output on the touched directory is byte-identical before and after (8 pre-existing problems either way).

## Backwards compatibility

`sqlite`, `mysql` and `pgsql` responses are unchanged — covered by the new tests. The only behavioural change is that a previously-blank step now renders.

## Issues

- fixes InvoiceShelf/docker#79