### PR TITLE
ci: fix updater registration and make it re-runnable

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,6 +9,10 @@ on:
         description: 'Docker tag'
         required: true
         default: 'latest'
+      register_tag:
+        description: 'Release tag to (re-)register on the updater, e.g. 2.4.2. Leave blank to skip.'
+        required: false
+        default: ''
 
 # Single source of truth for which major owns the moving stable tags
 # (:latest, :{major}, :{major}.{minor}) and the temporary :nightly alias.
@@ -136,30 +140,93 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
 
-      # Auto-register this release on the website updater backend so deployed installs
-      # are offered it. The zip is already built here (./InvoiceShelf.zip) and the checkout
-      # is present for config/installer.php, so this needs no re-download and can't race the
-      # asset upload. Idempotent per version (the endpoint upserts). Release fields are passed
-      # via env (not inline ${{ }}) to avoid shell injection from the release body.
-      - name: Register release on the website updater
+
+  # Registration lives in its own job, and fetches the published asset rather than
+  # reusing the build job's working directory. That decoupling is deliberate: the
+  # previous in-line step read `changelog.txt` relative to the checkout while writing
+  # it to /tmp, and the mismatch was undetectable until a real release ran. As its own
+  # job it can also be re-run on demand for an existing tag, so a failure here no longer
+  # requires production shell access to repair. Idempotent per version — the endpoint
+  # upserts. Release fields are passed via env (not inline ${{ }}) to avoid shell
+  # injection from the release body.
+  register_release:
+    name: 📡 Register release on the updater
+    # always() is required because release_artifact_build is skipped on a manual
+    # dispatch, and a job needing a skipped job is skipped too.
+    if: >-
+      always() &&
+      ((github.event_name == 'release' && needs.release_artifact_build.result == 'success') ||
+       (github.event_name == 'workflow_dispatch' && inputs.register_tag != ''))
+    needs:
+      - release_artifact_build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve the tag being registered
+        id: resolve
+        env:
+          EVENT: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.register_tag }}
+        run: |
+          if [ "$EVENT" = "release" ]; then TAG="$RELEASE_TAG"; else TAG="$INPUT_TAG"; fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      # config/installer.php is read at the tag being registered, not at HEAD, so a
+      # re-registration reports the requirements that release actually shipped with.
+      - name: Checkout code at that tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.resolve.outputs.tag }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          coverage: none
+
+      - name: Download the published release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: gh release download "$TAG" --repo "$GITHUB_REPOSITORY" -p InvoiceShelf.zip --clobber
+
+      - name: Register on the updater
+        id: register
         env:
           CI_RELEASE_TOKEN: ${{ secrets.WEBSITE_RELEASE_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
-          PRERELEASE: ${{ github.event.release.prerelease }}
-          PUBLISHED: ${{ github.event.release.published_at }}
-          BODY: ${{ github.event.release.body }}
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           if [ -z "$CI_RELEASE_TOKEN" ]; then
+            # A release that silently skips registration looks entirely successful while
+            # reaching nobody, so on a real release this is fatal. A manual dispatch
+            # without the secret is legitimate, so warn there instead.
+            if [ "$EVENT" = "release" ]; then
+              echo "::error::WEBSITE_RELEASE_TOKEN is not set — $TAG would never be offered to installs."
+              exit 1
+            fi
             echo "::warning::WEBSITE_RELEASE_TOKEN not set — skipping updater registration for $TAG"
+            echo "registered=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "registered=true" >> "$GITHUB_OUTPUT"
+
           MIN_PHP=$(php -r '$c=require "config/installer.php"; echo $c["core"]["minPhpVersion"] ?? "";')
           EXTS=$(php -r '$c=require "config/installer.php"; echo implode(", ", $c["requirements"]["php"] ?? []);')
-          printf '%s' "$BODY" > /tmp/changelog.txt
+
+          # Read the notes and pre-release flag from the release itself, so this behaves
+          # identically whether triggered by a publish or re-run later by hand.
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq '.body' > /tmp/changelog.txt
+          PRERELEASE=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')
+          PUBLISHED=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json publishedAt --jq '.publishedAt')
+
           case "$TAG" in
             *-*) CHANNEL=insider ;;
             *)   [ "$PRERELEASE" = "true" ] && CHANNEL=insider || CHANNEL=stable ;;
           esac
+
           echo "Registering $TAG (channel=$CHANNEL, min_php=$MIN_PHP) on the updater"
           curl -fsS --retry 3 --retry-delay 5 -X POST https://invoiceshelf.com/api/releases \
             -H "Authorization: Bearer $CI_RELEASE_TOKEN" \
@@ -168,9 +235,24 @@ jobs:
             -F "released_at=$PUBLISHED" \
             -F "min_php_version=$MIN_PHP" \
             -F "extensions=$EXTS" \
-            -F "changelog=<changelog.txt" \
-            -F "description=<changelog.txt" \
+            -F "changelog=</tmp/changelog.txt" \
+            -F "description=</tmp/changelog.txt" \
             -F "release_file=@InvoiceShelf.zip"
+
+      # Posting a 2xx is not proof an install can actually fetch the release. This
+      # endpoint 404s unless the Release row exists AND its zip is retrievable from
+      # storage, so it verifies the whole chain — and would have caught the failure
+      # this job was rewritten for.
+      - name: Verify the release is being served
+        if: steps.register.outputs.registered == 'true'
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          if ! curl -fsI --retry 3 --retry-delay 5 "https://invoiceshelf.com/releases/download/$TAG" > /dev/null; then
+            echo "::error::$TAG was accepted by the updater but is not being served — installs will not receive it."
+            exit 1
+          fi
+          echo "$TAG is registered and downloadable."
 
   release_docker_build:
     name: 🐳 Release Docker Build


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

**2.4.2 is published but is not being offered to any install.** The release exists, `InvoiceShelf.zip` is attached and the images built — registration on the updater failed:

```
Registering 2.4.2 (channel=stable, min_php=8.2.0) on the updater
curl: (26) Failed to open/read local data from file/application
```

The step wrote the changelog to `/tmp/changelog.txt` but told curl to read `changelog.txt` — a **relative** path, resolved against the repo checkout. `changelog` is `required` server-side, so nothing would have been accepted even if curl had sent the request. `release_file=@InvoiceShelf.zip` *is* correctly relative, which is why the mix looked plausible.

The step landed in #694, and every release since — 2.4.1, 3.0.0-alpha.1 — predates it. **2.4.2 is the first release to exercise this path.** The server side is well covered by the website's `ReleaseIngestTest`; the workflow shell had no test and could only run during a real release. That is the defect worth fixing, not just the path.

Three changes:

- **Registration is now its own job**, downloading the published asset via `gh release download` instead of reusing the build job's working directory — the coupling that made a relative path look reasonable. It runs on `release: published`, or on demand via `workflow_dispatch` with a `register_tag` input.
- **A missing `WEBSITE_RELEASE_TOKEN` is fatal on a release.** Previously it warned and exited 0, so a release could look entirely successful while reaching nobody — the same silent-failure class as the bug. A manual dispatch without the secret still warns and skips, which is legitimate.
- **The registration is verified.** `/releases/download/{tag}` 404s unless the `Release` row exists *and* its zip is retrievable from storage, so it proves the whole chain rather than trusting a 2xx. This would have caught the failure.

### Why this needs a re-runnable path

Re-running the failed job replays the workflow from the *tagged commit*, which still contains the bug. Without this, a registration failure can only be repaired with production shell access (`php artisan releases:import`) — which is exactly why 2.4.2 is currently stuck.

## Test plan

- `actionlint` (with shellcheck): **2 findings, byte-identical to `origin/2.x`** — both pre-existing `SC2016` info notes on the intentional `php -r '...'` snippets, where `$c` must not expand in shell. Nothing introduced.
- YAML parses; job graph is `php_syntax_errors → tests → release_artifact_build → register_release`, with `release_docker_build` and `manual_docker_build` unchanged.
- The verification probe was confirmed to discriminate against production before being wired in: `download/2.4.1` → **200**, `download/2.4.2` → **404**.

Two bugs found and fixed during review of my own change, both of which would have made the dispatch path dead on arrival:

- `release_artifact_build` is skipped on `workflow_dispatch`, and a job that `needs` a skipped job is itself skipped — so `register_release` needed `always()` plus explicit result checks.
- A step's own `env` is not resolved when its `if` is evaluated, so the verify step keys off an explicit step output rather than `env.CI_RELEASE_TOKEN != ''`.

**After merge**, this gets exercised for real: dispatch against `2.4.1` first — already registered, and `updateOrCreate` makes it a no-op re-upsert — then against `2.4.2` to close out the incident.

## Backwards compatibility

Workflow-only; no application code. The release path behaves as intended for the first time. The one behavioural change is that a release without the token now fails instead of quietly succeeding.

## Issues

- follows #694