### PR TITLE
ci: don't rebuild the docker image on a registration dispatch

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -297,7 +297,11 @@ jobs:
 
   manual_docker_build:
     name: 🛠️ Manual Docker Build
-    if: github.event_name == 'workflow_dispatch'
+    # A dispatch carrying register_tag is asking to register a release, not to
+    # build an image. Without this guard it would also run, and `tag` defaults to
+    # "latest" — so re-registering a release would rebuild from this branch and
+    # overwrite the published :latest image.
+    if: github.event_name == 'workflow_dispatch' && inputs.register_tag == ''
     needs:
       - tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

`manual_docker_build` fires on **any** `workflow_dispatch`, and pushes `invoiceshelf/invoiceshelf:{{ inputs.tag }}` — where `tag` is `required: true` with `default: latest`.

So dispatching the registration job added in #709 would *also* rebuild from the dispatched branch and **overwrite the published `:latest` image**. From 3.x that hands every `:latest` user a 3.0.0-alpha build; from 2.x it republishes latest from whatever ref was dispatched.

Found while about to run the post-merge dry run against `3.0.0-alpha.1` — which would have triggered exactly this. Nothing has been dispatched.

The registration path exists to be a *safe* recovery route, so triggering it must not carry that side effect. A dispatch carrying `register_tag` now runs registration only; a dispatch without it builds an image exactly as before.

## Test plan

- `actionlint` (with shellcheck): **2 findings, matching the branch baseline** — the pre-existing `SC2016` notes on the intentional `php -r` snippets.
- YAML parses; the resolved condition is `github.event_name == 'workflow_dispatch' && inputs.register_tag == ''`.
- On a `release` event the first clause short-circuits, so the job is skipped exactly as before.

## Backwards compatibility

A dispatch with `register_tag` blank — the only way it could be used before that branch existed — behaves identically.

## Issues

- follows #709
