### PR TITLE
ci: check the release notes before building

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,16 @@ jobs:
           extensions: bcmath, curl, dom, gd, imagick, json, libxml, mbstring, pcntl, pdo, pdo_mysql, zip
           tools: composer
 
+      - name: Read the release notes from CHANGELOG.md
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          if ! php .github/scripts/changelog-section.php "$TAG" > /tmp/notes.md; then
+            echo "::error::No CHANGELOG.md section for $TAG — add one before tagging."
+            exit 1
+          fi
+          echo "Using the CHANGELOG.md section for $TAG"
+
       - name: Install pnpm
         uses: pnpm/action-setup@v6
 
@@ -56,16 +66,6 @@ jobs:
       # ordering deciding what users received.
       - name: Build the release package
         run: make clean dist
-
-      - name: Read the release notes from CHANGELOG.md
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          if ! php .github/scripts/changelog-section.php "$TAG" > /tmp/notes.md; then
-            echo "::error::No CHANGELOG.md section for $TAG — add one before tagging."
-            exit 1
-          fi
-          echo "Using the CHANGELOG.md section for $TAG"
 
       # Created as a draft with the package already attached, then published as a
       # separate step. `release: published` therefore fires only once the tests


### PR DESCRIPTION
## Changes

`release.yaml` read the `CHANGELOG.md` section *after* composer install, pnpm install and the frontend build. Tagging without notes therefore spent a full build before failing on something knowable in the first seconds.

The step only needs PHP, so it now runs immediately after the PHP setup — ahead of every dependency install.

## How it was found

Dry-running a tag with no CHANGELOG section against #715, to confirm nothing gets published without notes. The guard worked exactly as intended — no release was created — but it took an entire build to say so.

## Test plan

- `actionlint`: **0 findings** on `release.yaml`.
- YAML parses; step order is now Checkout → Setup PHP → **Read notes** → pnpm → Node → Build → Draft → Publish.
- No behavioural change to the success path: the notes are read before the build either way, and `body_path` still points at the same file.

## Issues

- follows #715