### PR TITLE
ci: cut releases from a tag, with notes from CHANGELOG.md

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -46,100 +46,7 @@ jobs:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     needs:
       - php_syntax_errors
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version:
-          - 8.4
-    env:
-      extensions: bcmath, curl, dom, gd, imagick, json, libxml, mbstring, pcntl, pdo, pdo_mysql, zip
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup PHP Action
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: ${{ env.extensions }}
-          coverage: xdebug
-          tools: pecl, composer
-
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@4.0.0
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Use Node.js 24
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
-
-      - name: Compile Front-end
-        run: pnpm build
-
-      - name: Apply tests ${{ matrix.php-version }}
-        run: php artisan test
-
-  release_artifact_build:
-    name: 🏗️ Build / Upload - Release File
-    if: github.event_name == 'release'
-    needs:
-      - tests
-    runs-on: ubuntu-latest
-    env:
-      extensions: bcmath, curl, dom, gd, imagick, json, libxml, mbstring, pcntl, pdo, pdo_mysql, zip
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.4
-          extensions: ${{ env.extensions }}
-          coverage: none
-
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@4.0.0
-        with:
-          composer-options: --no-dev
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Use Node.js 24
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
-
-      - name: Compile Front-end
-        run: pnpm build
-
-      - name: Build Dist
-        run: |
-          make clean dist
-
-      - name: Upload package
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ github.token }}
-          file: InvoiceShelf.zip
-          asset_name: InvoiceShelf.zip
-          tag: ${{ github.ref }}
-          overwrite: true
-
+    uses: ./.github/workflows/tests.yaml
 
   # Registration lives in its own job, and fetches the published asset rather than
   # reusing the build job's working directory. That decoupling is deliberate: the
@@ -151,14 +58,13 @@ jobs:
   # injection from the release body.
   register_release:
     name: 📡 Register release on the updater
-    # always() is required because release_artifact_build is skipped on a manual
-    # dispatch, and a job needing a skipped job is skipped too.
+    # release.yaml attaches the package before publishing, so by the time this
+    # runs the asset is already there and no build dependency is needed. That also
+    # retires the always() dance this condition previously required to survive a
+    # skipped build job on a manual dispatch.
     if: >-
-      always() &&
-      ((github.event_name == 'release' && needs.release_artifact_build.result == 'success') ||
-       (github.event_name == 'workflow_dispatch' && inputs.register_tag != ''))
-    needs:
-      - release_artifact_build
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && inputs.register_tag != '')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,97 @@
+name: Release
+
+# Tagging is the trigger. Both spellings are accepted because every tag to date
+# is bare (3.0.0-alpha.1, 2.4.2) while this workflow previously listened only for
+# "v*" — so it had never once fired, and tagging by the established convention
+# produced silence.
+on:
+  push:
+    tags:
+      - '[0-9]*'
+      - 'v[0-9]*'
+
+permissions:
+  contents: write
+
+# Which major owns GitHub's "Latest release" pointer. Same value and same meaning
+# as in docker.yaml, which gates the moving :latest image tags on it — bump both
+# here and on 3.x when 3.0.0 GA is tagged.
+env:
+  LATEST_MAJOR: "2"
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yaml
+
+  release:
+    name: Build & Release
+    needs:
+      - tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: bcmath, curl, dom, gd, imagick, json, libxml, mbstring, pcntl, pdo, pdo_mysql, zip
+          tools: composer
+
+      - name: Read the release notes from CHANGELOG.md
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          if ! php .github/scripts/changelog-section.php "$TAG" > /tmp/notes.md; then
+            echo "::error::No CHANGELOG.md section for $TAG — add one before tagging."
+            exit 1
+          fi
+          echo "Using the CHANGELOG.md section for $TAG"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      # `make dist` owns the artifact: it installs composer/pnpm dependencies,
+      # builds the frontend, assembles the package and generates the manifest.
+      # This workflow used to hand-copy the same file list a second time, with
+      # docker.yaml then overwriting the result — two copies of one list, and job
+      # ordering deciding what users received.
+      - name: Build the release package
+        run: make clean dist
+
+      # Created as a draft with the package already attached, then published as a
+      # separate step. `release: published` therefore fires only once the tests
+      # have passed and the asset is in place, so downstream registration can
+      # never race the upload — and a failed run leaves no release at all rather
+      # than a published one nobody can download.
+      - name: Create the draft release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: InvoiceShelf.zip
+          body_path: /tmp/notes.md
+          draft: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+
+      - name: Publish it
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          # GitHub's "Latest release" pointer, gated exactly as docker.yaml gates
+          # its moving image tags — so a 3.0.0 alpha cannot displace 2.4.x as the
+          # release users are shown first while 2.x is still the stable line.
+          IS_LATEST: ${{ !contains(github.ref_name, '-') && startsWith(github.ref_name, format('{0}.', env.LATEST_MAJOR)) }}
+        run: |
+          if [ "$IS_LATEST" = "true" ]; then
+            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+          else
+            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest=false
+          fi
+          echo "Published $TAG (latest=$IS_LATEST)"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,51 @@
+name: Tests
+
+# Called by docker.yaml and release.yaml rather than written out in both. The
+# release artifact's file list already existed in two places on the 3.x branch
+# and drift was only a matter of time; the test definition should not repeat it.
+on:
+  workflow_call:
+
+jobs:
+  tests:
+    name: PHP Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - 8.4
+    env:
+      extensions: bcmath, curl, dom, gd, imagick, json, libxml, mbstring, pcntl, pdo, pdo_mysql, zip
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP Action
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: ${{ env.extensions }}
+          coverage: xdebug
+          tools: pecl, composer
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@4.0.0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Compile Front-end
+        run: pnpm build
+
+      - name: Apply tests ${{ matrix.php-version }}
+        run: php artisan test


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

Port of #715 and #716. Releases on this branch are published **by hand**, so the notes every install is offered are written at that moment rather than reviewed alongside the change. 2.4.2's were composed at the point of release, and nothing checked they existed or matched what shipped — #712 made `CHANGELOG.md` the source for *registration*, but a human still had to retype something into GitHub.

Tagging is now all that's required.

- **`release.yaml`** (new) — on a tag, reads the `CHANGELOG.md` section, builds via `make clean dist`, creates the release as a **draft with the package attached**, then publishes it as a separate step.
- **`tests.yaml`** (new) — the test definition, called by both workflows rather than written out twice.
- **`docker.yaml`** — `release_artifact_build` removed; `register_release` loses that dependency and the `always()` dance it needed to survive the job being skipped on a manual dispatch. Its condition is plain again.

### Why draft-then-publish

`release: published` now fires only once tests have passed **and** the asset is in place. So a failed run leaves **no release at all**, rather than a published one nobody can download — which is exactly what 2.4.2 left behind. It also means registration cannot race the asset upload, a race this restructure would otherwise have introduced, since `softprops/action-gh-release` creates the release before uploading files.

A tag with no `CHANGELOG.md` section fails **before anything is published**, and before any dependency is installed (#716).

`make_latest` is gated on `LATEST_MAJOR`, the same expression `docker.yaml` uses for its moving image tags.

## Test plan

The equivalent workflow was **exercised for real on 3.x** before this port: a dry-run tag with no changelog section triggered `release.yaml`, ran the reusable tests successfully, then failed at *"Read the release notes from CHANGELOG.md"* and **created no release**. Tag since deleted.

For this branch:

- `actionlint`: `release.yaml`, `tests.yaml`, `check.yaml` **clean**; `docker.yaml` **2 findings, matching baseline** (the pre-existing `SC2016` notes).
- No dangling references to the removed `release_artifact_build`; job graph resolves.
- The extractor resolves every tag that has a section — `2.4.3-beta.1` (703 bytes), `2.4.2` (2504), `2.4.0` (1926) — and exits **1** for `2.4.4`, which has none.
- **`release.yaml` differs from 3.x's only in comments** — verified by diff, so the two lines can't drift apart.

## Backwards compatibility

Publishing a release by hand still works exactly as before — `docker.yaml` still triggers on `release: published`, it simply no longer rebuilds an artifact that is already attached. The only new behaviour is that pushing a tag now does something.

Note this branch has no `scripts/generate-manifest.php`; that is 3.x-only and `make dist` here doesn't call it. `tests.yaml` carries this branch's own definition — xdebug coverage and a frontend build, where 3.x runs in parallel and splits out module tests.

## Issues

- ports #715, #716