### PR TITLE
ci: scope the pre-release docker aliases by line

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -187,8 +187,13 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') && startsWith(github.ref_name, format('{0}.', env.LATEST_MAJOR)) }}
-            type=raw,value=beta,enable=${{ contains(github.ref_name, '-beta') }}
-            type=raw,value=next,enable=${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}
+            # Scoped by line, or a pre-release on one line silently takes the
+            # other's alias: 2.4.3-beta.1 claimed :next from 3.0.0-alpha.1, moving
+            # anyone tracking the next major back onto a 2.x image. :beta is the
+            # stable line's pre-release, :next the newer major's — both gated on
+            # LATEST_MAJOR, exactly as :latest is.
+            type=raw,value=beta,enable=${{ contains(github.ref_name, '-beta') && startsWith(github.ref_name, format('{0}.', env.LATEST_MAJOR)) }}
+            type=raw,value=next,enable=${{ contains(github.ref_name, '-') && !startsWith(github.ref_name, format('{0}.', env.LATEST_MAJOR)) }}
             # DEPRECATED transitional alias: keeps existing :nightly deployments converging
             # onto stable until they migrate. Remove this line at the 3.0.0 GA flip.
             type=raw,value=nightly,enable=${{ !contains(github.ref_name, '-') && startsWith(github.ref_name, format('{0}.', env.LATEST_MAJOR)) }}


### PR DESCRIPTION
## Pre-review request checklist

- [x] (\*) I have listed all changes in the `Changes` section.
- [x] (opt) I have listed all issues this PR addresses in the `Issues` section.
- [x] (\*) I have tested my changes.
- [x] (\*) I have considered backwards compatibility.

## Changes

**`:next` was pointing at a 2.4.3 beta.** It is meant to track the next major line, but the rule was:

```yaml
type=raw,value=next,enable=${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}
```

Any pre-release claimed it. `2.4.3-beta.1` took it from `3.0.0-alpha.1` earlier today, and `2.4.3-beta.3` held it after — so anyone pulling `invoiceshelf/invoiceshelf:next` for a 3.0 alpha was **silently moved back onto a 2.x image**. A downgrade across a major line, caused by rehearsal betas that had no business touching that alias.

Confirmed against the registry rather than Docker Hub's API, which lags:

| tag | digest |
|---|---|
| `next` (before) | `sha256:2a019837…` ← the 2.4.3-beta.3 image |
| `3.0.0-alpha.1` | `sha256:33e28191…` |

`:beta` had the mirror of the same flaw — claimable by a pre-release on any line.

Both are now gated on `LATEST_MAJOR`, exactly as `:latest` already was: **`:beta` is the stable line's pre-release, `:next` the newer major's.**

## Already done on Docker Hub

`:next` has been **repointed to `3.0.0-alpha.1`**, using `docker buildx imagetools create` so the manifest list was copied rather than rebuilt — both `linux/amd64` and `linux/arm64` preserved. Verified: `next` and `3.0.0-alpha.1` now share digest `sha256:33e28191…`.

## Test plan

Gating verified across the cases that matter, with `LATEST_MAJOR=2`:

| tag | `:latest` | `:beta` | `:next` |
|---|---|---|---|
| `2.4.3-beta.3` | – | **yes** | – |
| `2.4.3` | **yes** | – | – |
| `3.0.0-alpha.2` | – | – | **yes** |
| `3.0.0-beta.1` | – | – | **yes** |
| `3.0.0` | – | – | – |

That last row is worth noting: at 3.0.0 GA neither alias applies until `LATEST_MAJOR` is bumped to `"3"`, which is the existing documented ritual and the same behaviour `:latest` has today.

- `actionlint`: 2 findings, matching the branch baseline.
- `publish.yaml` remains **byte-identical across both branches**.

## How this surfaced

The `2.4.3-beta.3` rehearsal. It succeeded end to end — draft, publish, registration, verification, images — and in checking the resulting tags this turned up. Worth saying plainly: the rehearsal betas caused the problem, and also caught it before a real 3.x release did.

## Issues

- follows #723, #724
