### PR TITLE
feat(pdf): repeating page headers and footers, and page numbers

### DIFF
--- a/app/Http/Controllers/Admin/Settings/PDFConfigurationController.php
+++ b/app/Http/Controllers/Admin/Settings/PDFConfigurationController.php
@@ -25,6 +25,15 @@ class PDFConfigurationController extends Controller
     ];
 
     /**
+     * Stored in the same string-valued settings table, so kept apart from the
+     * lengths above: it needs an explicit cast in both directions rather than
+     * being passed through.
+     */
+    private const PAGE_BOOLEANS = [
+        'pdf_page_numbers',
+    ];
+
+    /**
      * Returns the available drivers
      *
      * @throws AuthorizationException
@@ -53,6 +62,7 @@ class PDFConfigurationController extends Controller
         $pdfSettings = Setting::getSettings(array_merge(
             ['pdf_driver', 'gotenberg_host'],
             self::PAGE_SETTINGS,
+            self::PAGE_BOOLEANS,
         ));
 
         $config = [
@@ -64,6 +74,13 @@ class PDFConfigurationController extends Controller
         // returned rather than nested under a driver branch.
         foreach (self::PAGE_SETTINGS as $setting) {
             $config[$setting] = $pdfSettings[$setting] ?? config(self::configKeyFor($setting));
+        }
+
+        foreach (self::PAGE_BOOLEANS as $setting) {
+            $config[$setting] = filter_var(
+                $pdfSettings[$setting] ?? config(self::configKeyFor($setting)),
+                FILTER_VALIDATE_BOOLEAN
+            );
         }
 
         return response()->json($config);
@@ -103,6 +120,16 @@ class PDFConfigurationController extends Controller
         // Gotenberg-only setting.
         foreach (self::PAGE_SETTINGS as $setting) {
             $settings[$setting] = $request->get($setting);
+        }
+
+        // Only written when the form actually submitted it. Page numbers are a
+        // Gotenberg capability and the dompdf form does not render the control,
+        // so an unconditional write would clear the operator's choice every time
+        // they saved from the other driver.
+        foreach (self::PAGE_BOOLEANS as $setting) {
+            if ($request->has($setting)) {
+                $settings[$setting] = $request->boolean($setting) ? '1' : '0';
+            }
         }
 
         if ($driver === 'gotenberg') {

--- a/app/Http/Requests/PDFConfigurationRequest.php
+++ b/app/Http/Requests/PDFConfigurationRequest.php
@@ -45,6 +45,7 @@ class PDFConfigurationRequest extends FormRequest
             'pdf_margin_right' => $length,
             'pdf_margin_bottom' => $length,
             'pdf_margin_left' => $length,
+            'pdf_page_numbers' => ['sometimes', 'boolean'],
         ];
     }
 

--- a/app/Providers/AppConfigProvider.php
+++ b/app/Providers/AppConfigProvider.php
@@ -57,7 +57,7 @@ class AppConfigProvider extends ServiceProvider
             ];
 
             $pdfSettings = Setting::getSettings(array_merge(
-                ['pdf_driver', 'gotenberg_host'],
+                ['pdf_driver', 'gotenberg_host', 'pdf_page_numbers'],
                 array_keys($pageSettings),
             ));
 
@@ -76,6 +76,15 @@ class AppConfigProvider extends ServiceProvider
                 if (isset($pdfSettings[$setting]) && trim((string) $pdfSettings[$setting]) !== '') {
                     Config::set($configKey, $pdfSettings[$setting]);
                 }
+            }
+
+            // Stored as a string, so cast rather than passing '0' through as a
+            // truthy value.
+            if (isset($pdfSettings['pdf_page_numbers'])) {
+                Config::set(
+                    'pdf.page.page_numbers',
+                    filter_var($pdfSettings['pdf_page_numbers'], FILTER_VALIDATE_BOOLEAN)
+                );
             }
         } catch (\Exception $e) {
             // Silently fail if database is not available (during installation, migrations, etc.)

--- a/app/Support/Pdf/GotenbergPdfDriver.php
+++ b/app/Support/Pdf/GotenbergPdfDriver.php
@@ -6,6 +6,7 @@ use App\Support\Net\BlockedUrlException;
 use App\Support\Net\PrivateNetworkGuard;
 use Gotenberg\Gotenberg;
 use Gotenberg\Stream;
+use Illuminate\Support\Facades\View;
 use Psr\Http\Message\RequestInterface;
 
 class GotenbergPdfDriver implements PdfDriver
@@ -65,6 +66,16 @@ class GotenbergPdfDriver implements PdfDriver
             $chromium->landscape();
         }
 
+        // Must be attached before html(), which is terminal: it returns the built
+        // request rather than the builder.
+        if ($header = $this->companion($template, '_header')) {
+            $chromium->header(Stream::string('header.html', $header));
+        }
+
+        if ($footer = $this->companion($template, '_footer') ?? $this->defaultFooter()) {
+            $chromium->footer(Stream::string('footer.html', $footer));
+        }
+
         return $chromium->html(
             // The SDK renames this to index.html regardless of what we pass
             // (ChromiumPdf::html()), so name it that way rather than implying
@@ -74,5 +85,40 @@ class GotenbergPdfDriver implements PdfDriver
                 view($template)->render(),
             )
         );
+    }
+
+    /**
+     * A `{template}_header` or `{template}_footer` view rendered alongside the
+     * document, repeated by Chromium on every page.
+     *
+     * The suffix resolves through the `pdf_templates::` namespace too, so a
+     * custom template gets this without any extra wiring. PdfTemplateUtils hides
+     * the suffixed views from the template picker, which would otherwise list
+     * them as separately selectable templates.
+     */
+    private function companion(string $template, string $suffix): ?string
+    {
+        $view = $template.$suffix;
+
+        return View::exists($view) ? View::make($view)->render() : null;
+    }
+
+    /**
+     * Page numbers, when no template supplies a footer of its own.
+     *
+     * Gotenberg is the only driver that can do this: Chromium repeats a footer
+     * template on every page and substitutes the pageNumber/totalPages spans.
+     * dompdf has no equivalent, so the setting is presented under Gotenberg.
+     *
+     * Note the footer draws inside the bottom margin, so it is invisible when
+     * that margin is zero. The default of 1.2cm leaves room.
+     */
+    private function defaultFooter(): ?string
+    {
+        if (! config('pdf.page.page_numbers')) {
+            return null;
+        }
+
+        return View::make('app.pdf.partials.page-footer')->render();
     }
 }

--- a/app/Support/Pdf/PdfTemplateUtils.php
+++ b/app/Support/Pdf/PdfTemplateUtils.php
@@ -50,7 +50,18 @@ class PdfTemplateUtils
 
         $files = array_merge($files_native, $files_custom);
         $files = array_filter($files, function ($file) {
-            return Str::endsWith($file['path'], '.blade.php');
+            if (! Str::endsWith($file['path'], '.blade.php')) {
+                return false;
+            }
+
+            // `{template}_header` / `{template}_footer` are companions rendered
+            // alongside their template by the Gotenberg driver, not templates in
+            // their own right. Without this they show up in the picker as
+            // selectable entries with no preview image.
+            return ! Str::endsWith(
+                Str::before(basename($file['path']), '.blade.php'),
+                ['_header', '_footer']
+            );
         });
 
         return array_map(function ($file) use ($templateType, $imageFormat) {

--- a/config/pdf.php
+++ b/config/pdf.php
@@ -37,6 +37,14 @@ return [
         'margin_right' => env('PDF_MARGIN_RIGHT', '1.2cm'),
         'margin_bottom' => env('PDF_MARGIN_BOTTOM', '1.2cm'),
         'margin_left' => env('PDF_MARGIN_LEFT', '1.2cm'),
+
+        /*
+         * Repeat "page / total" at the foot of every page. Gotenberg only:
+         * Chromium repeats a footer template and substitutes the counts, and
+         * dompdf has no equivalent. Off by default so existing documents are
+         * unchanged. The footer draws inside the bottom margin, so it needs one.
+         */
+        'page_numbers' => env('PDF_PAGE_NUMBERS', false),
     ],
 
     /*

--- a/lang/en.json
+++ b/lang/en.json
@@ -1066,7 +1066,9 @@
       "margin_right": "Right Margin",
       "margin_bottom": "Bottom Margin",
       "margin_left": "Left Margin",
-      "length_hint": "A number and a unit, e.g. \"210mm\". Accepts: pt, px, pc, mm, cm, in."
+      "length_hint": "A number and a unit, e.g. \"210mm\". Accepts: pt, px, pc, mm, cm, in.",
+      "page_numbers": "Page Numbers",
+      "page_numbers_hint": "Repeat the page number at the foot of every page. Needs a bottom margin to sit in."
     },
     "company_info": {
       "company_info": "Company info",

--- a/resources/scripts/api/services/pdf.service.ts
+++ b/resources/scripts/api/services/pdf.service.ts
@@ -15,6 +15,12 @@ export interface PdfPageSetup {
   pdf_margin_right: string
   pdf_margin_bottom: string
   pdf_margin_left: string
+  /**
+   * Gotenberg only: Chromium repeats a footer template and substitutes the page
+   * counts. Carried by both driver forms even though only one renders the
+   * control, so saving from dompdf cannot clear the choice.
+   */
+  pdf_page_numbers: boolean
 }
 
 export interface DomPdfConfig extends PdfPageSetup {

--- a/resources/scripts/features/admin/components/settings/AdminPdfGotenbergDriver.vue
+++ b/resources/scripts/features/admin/components/settings/AdminPdfGotenbergDriver.vue
@@ -148,6 +148,7 @@ function saveConfig(): void {
       class="mt-6"
       :is-fetching-initial-data="isFetchingInitialData"
       :errors="pageErrors"
+      supports-page-numbers
     />
 
     <div class="flex my-10">

--- a/resources/scripts/features/admin/components/settings/AdminPdfPageSetup.vue
+++ b/resources/scripts/features/admin/components/settings/AdminPdfPageSetup.vue
@@ -17,6 +17,12 @@ const form = defineModel<PdfPageSetup>({ required: true })
 defineProps<{
   isFetchingInitialData?: boolean
   errors?: Record<string, string | false | undefined>
+  /**
+   * Page numbers rely on Chromium repeating a footer template, which dompdf has
+   * no equivalent of, so the control only appears for Gotenberg. The value is
+   * still carried by both forms so saving from dompdf cannot clear it.
+   */
+  supportsPageNumbers?: boolean
 }>()
 
 // Convenience only. Storage is always a pair of CSS lengths, because Gotenberg
@@ -166,6 +172,14 @@ const orientations = computed(() => [
         type="text"
         name="pdf_margin_right"
       />
+    </BaseInputGroup>
+
+    <BaseInputGroup
+      v-if="supportsPageNumbers"
+      :label="$t('settings.pdf.page_numbers')"
+      :help-text="$t('settings.pdf.page_numbers_hint')"
+    >
+      <BaseSwitch v-model="form.pdf_page_numbers" class="flex" />
     </BaseInputGroup>
   </BaseInputGrid>
 </template>

--- a/resources/scripts/features/admin/components/settings/pdfPageSetup.ts
+++ b/resources/scripts/features/admin/components/settings/pdfPageSetup.ts
@@ -37,17 +37,22 @@ export function pageSetupDefaults(): PdfPageSetup {
     pdf_margin_right: '1.2cm',
     pdf_margin_bottom: '1.2cm',
     pdf_margin_left: '1.2cm',
+    pdf_page_numbers: false,
   }
 }
 
 /** Pulls the page-setup keys out of the API payload, skipping anything absent. */
 export function pageSetupFrom(configData: Record<string, unknown>): Partial<PdfPageSetup> {
-  const setup: Record<string, string> = {}
+  const setup: Record<string, string | boolean> = {}
 
   for (const key of PAGE_SETUP_KEYS) {
     if (typeof configData[key] === 'string' && configData[key]) {
       setup[key] = configData[key] as string
     }
+  }
+
+  if (typeof configData.pdf_page_numbers === 'boolean') {
+    setup.pdf_page_numbers = configData.pdf_page_numbers
   }
 
   return setup as Partial<PdfPageSetup>

--- a/resources/views/app/pdf/partials/page-footer.blade.php
+++ b/resources/views/app/pdf/partials/page-footer.blade.php
@@ -1,0 +1,19 @@
+{{--
+    Chromium's footer template, repeated on every page.
+
+    Every style is inline on purpose: Chromium renders header and footer
+    templates in their own context, inheriting none of the document's CSS, and
+    defaults them to a font size small enough to look blank. It substitutes the
+    pageNumber and totalPages spans itself.
+
+    Deliberately not localised. The spans are replaced by the browser, so
+    wrapping words around them ("Page X of Y") reads badly once translated and
+    cannot be reordered per locale. A numeral pair carries the same meaning
+    everywhere.
+
+    The footer draws inside the bottom page margin, so it is invisible if that
+    margin is zero. See Settings -> PDF Generation.
+--}}
+<div style="font-size:9px;width:100%;padding:0 15mm;color:#6b7280;text-align:right;font-family:sans-serif;">
+    <span class="pageNumber"></span> / <span class="totalPages"></span>
+</div>

--- a/tests/Feature/Admin/AdminSettingsTest.php
+++ b/tests/Feature/Admin/AdminSettingsTest.php
@@ -228,6 +228,60 @@ test('pdf configuration rejects an unknown orientation', function () {
  * with !empty(), and '0mm' is fine there, but a bare '0' would not be -- this
  * pins the behaviour either way.
  */
+test('page numbers can be turned on and read back', function () {
+    postJson('/api/v1/pdf/config', [
+        'pdf_driver' => 'gotenberg',
+        'gotenberg_host' => 'https://pdf.example.com',
+        'pdf_paper_width' => '210mm',
+        'pdf_paper_height' => '297mm',
+        'pdf_orientation' => 'portrait',
+        'pdf_page_numbers' => true,
+    ])->assertOk();
+
+    getJson('/api/v1/pdf/config')->assertOk()->assertJson(['pdf_page_numbers' => true]);
+});
+
+/**
+ * The dompdf form does not render the page-numbers control, since dompdf cannot
+ * repeat a footer. Saving from it must leave the stored choice alone rather than
+ * writing an absent field as false.
+ */
+test('saving from the dompdf form leaves the page-number choice alone', function () {
+    postJson('/api/v1/pdf/config', [
+        'pdf_driver' => 'gotenberg',
+        'gotenberg_host' => 'https://pdf.example.com',
+        'pdf_paper_width' => '210mm',
+        'pdf_paper_height' => '297mm',
+        'pdf_orientation' => 'portrait',
+        'pdf_page_numbers' => true,
+    ])->assertOk();
+
+    postJson('/api/v1/pdf/config', [
+        'pdf_driver' => 'dompdf',
+        'pdf_paper_width' => '210mm',
+        'pdf_paper_height' => '297mm',
+        'pdf_orientation' => 'portrait',
+    ])->assertOk();
+
+    getJson('/api/v1/pdf/config')->assertOk()->assertJson(['pdf_page_numbers' => true]);
+});
+
+test('page numbers can be turned back off', function () {
+    postJson('/api/v1/pdf/config', [
+        'pdf_driver' => 'gotenberg',
+        'gotenberg_host' => 'https://pdf.example.com',
+        'pdf_paper_width' => '210mm',
+        'pdf_paper_height' => '297mm',
+        'pdf_orientation' => 'portrait',
+        'pdf_page_numbers' => false,
+    ])->assertOk();
+
+    // Stored as the string '0', which !empty() would have discarded.
+    $this->assertDatabaseHas('settings', ['option' => 'pdf_page_numbers', 'value' => '0']);
+
+    getJson('/api/v1/pdf/config')->assertOk()->assertJson(['pdf_page_numbers' => false]);
+});
+
 test('a zero margin survives the round trip', function () {
     postJson('/api/v1/pdf/config', [
         'pdf_driver' => 'dompdf',

--- a/tests/Feature/Pdf/PdfTemplateListingTest.php
+++ b/tests/Feature/Pdf/PdfTemplateListingTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Support\Pdf\PdfTemplateUtils;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * getFormattedTemplates() lists every .blade.php it finds, which is how the
+ * picker is populated. Companion header/footer views live next to their template
+ * and are rendered with it, not chosen instead of it, so listing them would put
+ * previewless entries in the dialog.
+ */
+beforeEach(function () {
+    Storage::fake('pdf_templates');
+
+    $this->customDir = Storage::disk('pdf_templates')->path('invoice');
+    File::ensureDirectoryExists($this->customDir);
+});
+
+function writeCustomTemplate(string $dir, string $name): void
+{
+    File::put("{$dir}/{$name}.blade.php", '<html></html>');
+}
+
+test('companion views are kept out of the template picker', function () {
+    writeCustomTemplate($this->customDir, 'branded');
+    writeCustomTemplate($this->customDir, 'branded_header');
+    writeCustomTemplate($this->customDir, 'branded_footer');
+
+    $names = array_column(PdfTemplateUtils::getFormattedTemplates('invoice', ''), 'name');
+
+    expect($names)->toContain('branded')
+        ->and($names)->not->toContain('branded_header')
+        ->and($names)->not->toContain('branded_footer');
+});
+
+test('the stock templates are still listed', function () {
+    $names = array_column(PdfTemplateUtils::getFormattedTemplates('invoice', ''), 'name');
+
+    expect($names)->toContain('invoice1', 'invoice2', 'invoice3');
+});
+
+/**
+ * The exclusion matches on the suffix, so a template whose name merely mentions
+ * a header is unaffected.
+ */
+test('a template whose name only contains the word is still listed', function () {
+    writeCustomTemplate($this->customDir, 'header_led_design');
+
+    $names = array_column(PdfTemplateUtils::getFormattedTemplates('invoice', ''), 'name');
+
+    expect($names)->toContain('header_led_design');
+});

--- a/tests/Unit/GotenbergCompanionViewTest.php
+++ b/tests/Unit/GotenbergCompanionViewTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use App\Support\Pdf\GotenbergPdfDriver;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\View;
+
+/**
+ * Chromium repeats a header/footer template on every page. A `{template}_header`
+ * or `{template}_footer` view alongside the document opts into that, and page
+ * numbers are the built-in footer for templates that supply none.
+ *
+ * Assertions are on the multipart request rather than a rendered PDF, so no
+ * Gotenberg service is needed. The rendered check against a live gotenberg:8 is
+ * in the PR description.
+ *
+ * Views are written to a temp namespace rather than resources/views so they stay
+ * out of the template picker and out of the render test's glob.
+ */
+beforeEach(function () {
+    config([
+        'pdf.connections.gotenberg.host' => 'http://gotenberg.example.com:3000',
+        'pdf.page.page_numbers' => false,
+    ]);
+
+    $this->views = sys_get_temp_dir().'/is-companion-'.uniqid();
+    File::ensureDirectoryExists($this->views);
+    View::addNamespace('companion', $this->views);
+
+    $this->writeView = function (string $name, string $contents) {
+        File::put($this->views."/{$name}.blade.php", $contents);
+    };
+
+    ($this->writeView)('doc', '<html><body>document body</body></html>');
+});
+
+afterEach(function () {
+    File::deleteDirectory($this->views);
+});
+
+function companionRequestBody(string $view = 'companion::doc'): string
+{
+    return (string) (new GotenbergPdfDriver)->buildRequest($view)->getBody();
+}
+
+test('a template with no companions and no page numbers sends neither', function () {
+    $body = companionRequestBody();
+
+    expect($body)->not->toContain('header.html')
+        ->and($body)->not->toContain('footer.html');
+});
+
+test('a companion header is sent alongside the document', function () {
+    ($this->writeView)('doc_header', '<div>COMPANION HEADER</div>');
+
+    $body = companionRequestBody();
+
+    expect($body)->toContain('header.html')
+        ->and($body)->toContain('COMPANION HEADER')
+        ->and($body)->not->toContain('footer.html');
+});
+
+test('a companion footer is sent alongside the document', function () {
+    ($this->writeView)('doc_footer', '<div>COMPANION FOOTER</div>');
+
+    $body = companionRequestBody();
+
+    expect($body)->toContain('footer.html')
+        ->and($body)->toContain('COMPANION FOOTER');
+});
+
+test('page numbers supply a footer when the template has none', function () {
+    config(['pdf.page.page_numbers' => true]);
+
+    $body = companionRequestBody();
+
+    expect($body)->toContain('footer.html')
+        ->and($body)->toContain('pageNumber')
+        ->and($body)->toContain('totalPages');
+});
+
+/**
+ * A template that went to the trouble of defining a footer should keep it, so
+ * enabling page numbers must not overwrite it.
+ */
+test('a companion footer wins over the page-number default', function () {
+    config(['pdf.page.page_numbers' => true]);
+    ($this->writeView)('doc_footer', '<div>COMPANION FOOTER</div>');
+
+    $body = companionRequestBody();
+
+    expect($body)->toContain('COMPANION FOOTER')
+        ->and($body)->not->toContain('pageNumber');
+});
+
+test('page numbers stay off by default so existing documents are unchanged', function () {
+    expect(config('pdf.page.page_numbers'))->toBeFalsy();
+});


### PR DESCRIPTION
Stacked on #728 (which is stacked on #727). Takes over #690 by @csoscd — the companion-view idea is theirs; this reworks it onto the shared page setup and fills the gaps that stopped it landing.

## What

A `{template}_header` or `{template}_footer` view next to a template is rendered alongside it and repeated by Chromium on every page. The suffix resolves through the `pdf_templates::` namespace too, so custom templates get it with no extra wiring.

## Two things had to change for that to be useful

**Companion views are now hidden from the template picker.** `getFormattedTemplates()` lists every `.blade.php` it finds, so an `invoice1_footer` would otherwise show up in the "Choose a Template" dialog as a separately selectable entry with no preview image. #690 would have introduced that the moment anyone used the feature.

**It does something out of the box.** #690 shipped no companion views, so both of its margin settings were visible no-ops until someone hand-wrote a Blade file — on Docker, inside an image. Instead there is a `pdf_page_numbers` setting, off by default, supplying a footer when a template has none:

```html
<span class="pageNumber"></span> / <span class="totalPages"></span>
```

Every style on it is inline, because Chromium renders header/footer templates in their own context inheriting none of the document's CSS, and defaults them to a font size small enough to look blank. Not localised on purpose: the browser substitutes the spans, so wrapping words around them ("Page X of Y") cannot be reordered per locale, whereas a numeral pair reads the same everywhere.

A template's own companion still wins, so enabling page numbers cannot overwrite a designed footer.

## Where the setting lives

Under Gotenberg, because only Chromium can repeat a footer — dompdf has no equivalent. But the value is carried by the dompdf form too, and the controller only writes it when the request contains it. Otherwise saving from the dompdf screen, which does not render the control, would silently clear the choice. There is a test for exactly that.

## Margins

From the shared page setup (#728), not #690's separate `header_margin` / `footer_margin`. Chromium draws the header and footer *inside* the page margin, so the existing margins already are the space they occupy; two more settings for the same distance would be a second way to say the same thing. The field hint notes that page numbers need a bottom margin to sit in.

## Verified against a live gotenberg:8

Two-page document, text extracted per page:

| setting | result |
|---|---|
| page numbers off | `page one` `page two` |
| page numbers on | `page one` `1/2` `page two` `2/2` |
| companion footer present | `page one` `COMPANION FOOTER` `page two` `COMPANION FOOTER` |

## On #690's test

Not carried over, because it asserted nothing. A bare `View::shouldReceive('exists')` is an allowance rather than an expectation, `andReturn(false)` never entered the companion branch, and the whole call sat inside `try { } catch (Throwable) { }` — it passed with the feature deleted. Replaced with `GotenbergCompanionViewTest` (six cases on the real multipart request) and `PdfTemplateListingTest` (picker exclusion, including that a template merely *named* `header_led_design` is unaffected).

Full suite: 609 passed.
