### PR TITLE
feat(pdf): archival PDF/A output and document properties

### DIFF
--- a/app/Facades/Pdf.php
+++ b/app/Facades/Pdf.php
@@ -5,7 +5,7 @@ namespace App\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static \App\Support\Pdf\ResponseStream loadView(string $template)
+ * @method static \App\Support\Pdf\ResponseStream loadView(string $template, array $metadata = [])
  */
 class Pdf extends Facade
 {

--- a/app/Http/Controllers/Admin/Settings/PDFConfigurationController.php
+++ b/app/Http/Controllers/Admin/Settings/PDFConfigurationController.php
@@ -60,7 +60,7 @@ class PDFConfigurationController extends Controller
         $this->authorize('manage pdf config');
 
         $pdfSettings = Setting::getSettings(array_merge(
-            ['pdf_driver', 'gotenberg_host'],
+            ['pdf_driver', 'gotenberg_host', 'gotenberg_pdfa'],
             self::PAGE_SETTINGS,
             self::PAGE_BOOLEANS,
         ));
@@ -68,6 +68,7 @@ class PDFConfigurationController extends Controller
         $config = [
             'pdf_driver' => $pdfSettings['pdf_driver'] ?? config('pdf.driver'),
             'gotenberg_host' => $pdfSettings['gotenberg_host'] ?? config('pdf.connections.gotenberg.host'),
+            'gotenberg_pdfa' => $pdfSettings['gotenberg_pdfa'] ?? config('pdf.connections.gotenberg.pdfa') ?? '',
         ];
 
         // Page geometry applies to whichever driver is selected, so it is always
@@ -134,6 +135,7 @@ class PDFConfigurationController extends Controller
 
         if ($driver === 'gotenberg') {
             $settings['gotenberg_host'] = $request->get('gotenberg_host');
+            $settings['gotenberg_pdfa'] = $request->get('gotenberg_pdfa') ?? '';
         }
 
         return $settings;

--- a/app/Http/Requests/PDFConfigurationRequest.php
+++ b/app/Http/Requests/PDFConfigurationRequest.php
@@ -10,6 +10,9 @@ use Illuminate\Validation\Rule;
 
 class PDFConfigurationRequest extends FormRequest
 {
+    /** Formats the Gotenberg image can actually produce, verified against gotenberg:8. */
+    public const PDFA_FORMATS = ['PDF/A-1b', 'PDF/A-2b', 'PDF/A-3b'];
+
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -67,6 +70,10 @@ class PDFConfigurationRequest extends FormRequest
                 'url',
                 Rule::when(! $isDeclaredHost, [new PublicHttpUrl]),
             ],
+            // A fixed list rather than a free string: the SDK forwards whatever
+            // it is given, so an unsupported value would only fail later as an
+            // HTTP error from the Gotenberg service.
+            'gotenberg_pdfa' => ['nullable', Rule::in(self::PDFA_FORMATS)],
         ];
     }
 }

--- a/app/Providers/AppConfigProvider.php
+++ b/app/Providers/AppConfigProvider.php
@@ -57,15 +57,23 @@ class AppConfigProvider extends ServiceProvider
             ];
 
             $pdfSettings = Setting::getSettings(array_merge(
-                ['pdf_driver', 'gotenberg_host', 'pdf_page_numbers'],
+                ['pdf_driver', 'gotenberg_host', 'gotenberg_pdfa', 'pdf_page_numbers'],
                 array_keys($pageSettings),
             ));
 
             if (! empty($pdfSettings['pdf_driver'])) {
                 Config::set('pdf.driver', $pdfSettings['pdf_driver']);
 
-                if ($pdfSettings['pdf_driver'] === 'gotenberg' && ! empty($pdfSettings['gotenberg_host'])) {
-                    Config::set('pdf.connections.gotenberg.host', $pdfSettings['gotenberg_host']);
+                if ($pdfSettings['pdf_driver'] === 'gotenberg') {
+                    if (! empty($pdfSettings['gotenberg_host'])) {
+                        Config::set('pdf.connections.gotenberg.host', $pdfSettings['gotenberg_host']);
+                    }
+
+                    // Empty is a real choice here -- it means an ordinary PDF --
+                    // so an explicitly stored blank must override an env default.
+                    if (isset($pdfSettings['gotenberg_pdfa'])) {
+                        Config::set('pdf.connections.gotenberg.pdfa', $pdfSettings['gotenberg_pdfa'] ?: null);
+                    }
                 }
             }
 

--- a/app/Services/Document/EstimateService.php
+++ b/app/Services/Document/EstimateService.php
@@ -13,6 +13,7 @@ use App\Models\Estimate;
 use App\Models\ExchangeRateLog;
 use App\Models\Invoice;
 use App\Services\Mail\CompanyMailConfigService;
+use App\Support\Pdf\PdfMetadata;
 use App\Support\Pdf\PdfTemplateUtils;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -201,7 +202,11 @@ class EstimateService
             return view($templatePath);
         }
 
-        return Pdf::loadView($templatePath);
+        return Pdf::loadView($templatePath, PdfMetadata::forDocument(
+            __('pdf_estimate_label'),
+            $estimate->estimate_number,
+            $company,
+        ));
     }
 
     public function clone(Estimate $estimate): Estimate

--- a/app/Services/Document/InvoiceService.php
+++ b/app/Services/Document/InvoiceService.php
@@ -13,6 +13,7 @@ use App\Models\Estimate;
 use App\Models\ExchangeRateLog;
 use App\Models\Invoice;
 use App\Services\Mail\CompanyMailConfigService;
+use App\Support\Pdf\PdfMetadata;
 use App\Support\Pdf\PdfTemplateUtils;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -265,7 +266,11 @@ class InvoiceService
             return view($templatePath);
         }
 
-        return Pdf::loadView($templatePath);
+        return Pdf::loadView($templatePath, PdfMetadata::forDocument(
+            __('pdf_invoice_label'),
+            $invoice->invoice_number,
+            $company,
+        ));
     }
 
     public function clone(Invoice $invoice): Invoice

--- a/app/Services/Document/PaymentService.php
+++ b/app/Services/Document/PaymentService.php
@@ -11,6 +11,7 @@ use App\Models\ExchangeRateLog;
 use App\Models\Invoice;
 use App\Models\Payment;
 use App\Services\Mail\CompanyMailConfigService;
+use App\Support\Pdf\PdfMetadata;
 use App\Support\Pdf\PdfTemplateUtils;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -188,7 +189,11 @@ class PaymentService
             return view($templatePath);
         }
 
-        return Pdf::loadView($templatePath);
+        return Pdf::loadView($templatePath, PdfMetadata::forDocument(
+            __('pdf_payment_label'),
+            $payment->payment_number,
+            $company,
+        ));
     }
 
     public function generateFromTransaction($transaction): Payment

--- a/app/Support/Pdf/DompdfDriver.php
+++ b/app/Support/Pdf/DompdfDriver.php
@@ -15,13 +15,20 @@ use Illuminate\Support\Facades\App;
  */
 class DompdfDriver implements PdfDriver
 {
-    public function loadView(string $template): ResponseStream
+    public function loadView(string $template, array $metadata = []): ResponseStream
     {
         $page = PdfPageSetup::fromConfig();
 
+        $html = $this->withPageMargins(view($template)->render(), $page);
+        $html = $this->withDocumentTitle($html, $metadata['Title'] ?? null);
+
         $pdf = $this->wrapper();
         $pdf->setPaper($page->dompdfPaper(), $page->orientation);
-        $pdf->loadHTML($this->withPageMargins(view($template)->render(), $page));
+        $pdf->loadHTML($html);
+
+        if ($metadata !== []) {
+            $pdf->addInfo($metadata);
+        }
 
         return new DompdfResponse($pdf);
     }
@@ -42,6 +49,39 @@ class DompdfDriver implements PdfDriver
         $injected = preg_replace('/(<head\b[^>]*>)/i', '$1'.$style, $html, 1, $count);
 
         return $count ? $injected : $style.$html;
+    }
+
+    /**
+     * dompdf reads the document Title from the <title> element during render(),
+     * which happens after any addInfo() call, so metadata set through the API is
+     * silently overwritten by whatever the template happened to put there. The
+     * only way to make the two drivers agree on the title is to write it into
+     * the markup.
+     */
+    private function withDocumentTitle(string $html, ?string $title): string
+    {
+        if ($title === null || $title === '') {
+            return $html;
+        }
+
+        $escaped = htmlspecialchars($title, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        $replaced = preg_replace(
+            '#<title\b[^>]*>.*?</title>#is',
+            "<title>{$escaped}</title>",
+            $html,
+            1,
+            $count
+        );
+
+        if ($count) {
+            return $replaced;
+        }
+
+        // No <title> to replace, so add one. dompdf only looks inside <head>.
+        $injected = preg_replace('/(<head\b[^>]*>)/i', "$1<title>{$escaped}</title>", $html, 1, $count);
+
+        return $count ? $injected : $html;
     }
 
     protected function wrapper(): PDF

--- a/app/Support/Pdf/GotenbergPdfDriver.php
+++ b/app/Support/Pdf/GotenbergPdfDriver.php
@@ -11,9 +11,9 @@ use Psr\Http\Message\RequestInterface;
 
 class GotenbergPdfDriver implements PdfDriver
 {
-    public function loadView(string $template): ResponseStream
+    public function loadView(string $template, array $metadata = []): ResponseStream
     {
-        return new GotenbergPdfResponse(Gotenberg::send($this->buildRequest($template)));
+        return new GotenbergPdfResponse(Gotenberg::send($this->buildRequest($template, $metadata)));
     }
 
     /**
@@ -23,7 +23,7 @@ class GotenbergPdfDriver implements PdfDriver
      * below this line used to be inlined into loadView(), which meant the only
      * way to check that an option was set was to run a Gotenberg service.
      */
-    public function buildRequest(string $template): RequestInterface
+    public function buildRequest(string $template, array $metadata = []): RequestInterface
     {
         $page = PdfPageSetup::fromConfig();
         [$width, $height] = $page->gotenbergPaper();
@@ -64,6 +64,19 @@ class GotenbergPdfDriver implements PdfDriver
         // the portrait pair — the same convention dompdf's setPaper() follows.
         if ($page->isLandscape()) {
             $chromium->landscape();
+        }
+
+        // Archival conformance, converted by LibreOffice inside the Gotenberg
+        // image. PDF/A-3 is what the EU e-invoicing formats ask for. The value is
+        // passed through unvalidated by the SDK, so an unsupported one surfaces
+        // as an HTTP error from the service; the setting is a fixed list for
+        // that reason.
+        if ($pdfa = config('pdf.connections.gotenberg.pdfa')) {
+            $chromium->pdfa($pdfa);
+        }
+
+        if ($metadata !== []) {
+            $chromium->metadata($metadata);
         }
 
         // Must be attached before html(), which is terminal: it returns the built

--- a/app/Support/Pdf/PdfDriver.php
+++ b/app/Support/Pdf/PdfDriver.php
@@ -4,5 +4,11 @@ namespace App\Support\Pdf;
 
 interface PdfDriver
 {
-    public function loadView(string $template): ResponseStream;
+    /**
+     * @param  array<string, string>  $metadata  Document properties written into
+     *                                           the file: Title, Author, Subject,
+     *                                           Keywords, Creator. Both drivers
+     *                                           accept the same key names.
+     */
+    public function loadView(string $template, array $metadata = []): ResponseStream;
 }

--- a/app/Support/Pdf/PdfMetadata.php
+++ b/app/Support/Pdf/PdfMetadata.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Support\Pdf;
+
+use App\Models\Company;
+
+/**
+ * Document properties written into the PDF itself.
+ *
+ * Generated files used to carry none, so an archive of them showed a column of
+ * blank titles and no author. It also matters for PDF/A, whose whole point is
+ * being readable years later by someone who has only the file.
+ *
+ * Both drivers take the same key names: dompdf via addInfo(), Gotenberg via
+ * metadata().
+ */
+final class PdfMetadata
+{
+    /**
+     * @return array<string, string>
+     */
+    public static function forDocument(string $subject, ?string $number, ?Company $company): array
+    {
+        $title = trim($subject.' '.($number ?? ''));
+
+        return array_filter([
+            'Title' => $title,
+            'Subject' => $subject,
+            'Author' => $company?->name,
+            'Creator' => config('app.name', 'InvoiceShelf'),
+        ], fn ($value) => is_string($value) && $value !== '');
+    }
+}

--- a/app/Support/Pdf/PdfService.php
+++ b/app/Support/Pdf/PdfService.php
@@ -4,10 +4,10 @@ namespace App\Support\Pdf;
 
 class PdfService
 {
-    public static function loadView(string $template): ResponseStream
+    public static function loadView(string $template, array $metadata = []): ResponseStream
     {
         $driver = config('pdf.driver');
 
-        return PdfDriverFactory::create($driver)->loadView($template);
+        return PdfDriverFactory::create($driver)->loadView($template, $metadata);
     }
 }

--- a/config/pdf.php
+++ b/config/pdf.php
@@ -65,6 +65,14 @@ return [
             'host' => env('GOTENBERG_HOST', 'http://pdf:3000'),
 
             /*
+             * Archival conformance, converted by LibreOffice inside the Gotenberg
+             * image. Empty means an ordinary PDF. PDF/A-3 is what the EU
+             * e-invoicing formats ask for. Gotenberg only: dompdf cannot produce
+             * PDF/A.
+             */
+            'pdfa' => env('GOTENBERG_PDFA'),
+
+            /*
              * Gotenberg usually runs as a sidecar on a private network, which the
              * SSRF guard rejects. Name that one host here to exempt it — e.g.
              * GOTENBERG_ALLOWED_PRIVATE_HOST=http://pdf:3000. Only this exact value

--- a/lang/en.json
+++ b/lang/en.json
@@ -1068,7 +1068,10 @@
       "margin_left": "Left Margin",
       "length_hint": "A number and a unit, e.g. \"210mm\". Accepts: pt, px, pc, mm, cm, in.",
       "page_numbers": "Page Numbers",
-      "page_numbers_hint": "Repeat the page number at the foot of every page. Needs a bottom margin to sit in."
+      "page_numbers_hint": "Repeat the page number at the foot of every page. Needs a bottom margin to sit in.",
+      "pdfa": "Archival Format (PDF/A)",
+      "pdfa_hint": "Long-term archival conformance. PDF/A-3 is what EU e-invoicing formats expect. Leave off for an ordinary PDF.",
+      "pdfa_off": "Off"
     },
     "company_info": {
       "company_info": "Company info",

--- a/resources/scripts/api/services/pdf.service.ts
+++ b/resources/scripts/api/services/pdf.service.ts
@@ -30,6 +30,8 @@ export interface DomPdfConfig extends PdfPageSetup {
 export interface GotenbergConfig extends PdfPageSetup {
   pdf_driver: string
   gotenberg_host: string
+  /** '' for an ordinary PDF, or one of the PDF/A conformance levels. */
+  gotenberg_pdfa: string
 }
 
 export type PdfConfig = DomPdfConfig | GotenbergConfig

--- a/resources/scripts/features/admin/components/settings/AdminPdfGotenbergDriver.vue
+++ b/resources/scripts/features/admin/components/settings/AdminPdfGotenbergDriver.vue
@@ -37,8 +37,19 @@ const { t } = useI18n()
 const form = reactive<GotenbergConfig>({
   pdf_driver: 'gotenberg',
   gotenberg_host: '',
+  gotenberg_pdfa: '',
   ...pageSetupDefaults(),
 })
+
+// Only what the Gotenberg image can actually produce, checked against
+// gotenberg:8. The SDK forwards the value unvalidated, so anything else would
+// fail as an HTTP error at render time.
+const pdfaFormats = computed(() => [
+  { label: t('settings.pdf.pdfa_off'), value: '' },
+  { label: 'PDF/A-1b', value: 'PDF/A-1b' },
+  { label: 'PDF/A-2b', value: 'PDF/A-2b' },
+  { label: 'PDF/A-3b', value: 'PDF/A-3b' },
+])
 
 function isValidServiceUrl(value: string): boolean {
   if (!helpers.req(value)) {
@@ -87,6 +98,10 @@ onMounted(() => {
 
   if (typeof props.configData.gotenberg_host === 'string') {
     form.gotenberg_host = props.configData.gotenberg_host
+  }
+
+  if (typeof props.configData.gotenberg_pdfa === 'string') {
+    form.gotenberg_pdfa = props.configData.gotenberg_pdfa
   }
 
   Object.assign(form, pageSetupFrom(props.configData))
@@ -139,6 +154,20 @@ function saveConfig(): void {
           type="text"
           name="gotenberg_host"
           @input="v$.gotenberg_host.$touch()"
+        />
+      </BaseInputGroup>
+
+      <BaseInputGroup
+        :label="$t('settings.pdf.pdfa')"
+        :help-text="$t('settings.pdf.pdfa_hint')"
+      >
+        <BaseMultiselect
+          v-model="form.gotenberg_pdfa"
+          :content-loading="isFetchingInitialData"
+          :options="pdfaFormats"
+          label="label"
+          value-prop="value"
+          :can-deselect="false"
         />
       </BaseInputGroup>
     </BaseInputGrid>

--- a/tests/Feature/Admin/AdminSettingsTest.php
+++ b/tests/Feature/Admin/AdminSettingsTest.php
@@ -305,3 +305,43 @@ test('get app version', function () {
             'channel',
         ]);
 });
+
+/**
+ * The SDK forwards the pdfa value unvalidated, so an unsupported one would only
+ * fail later as an HTTP error from the Gotenberg service. The setting is a fixed
+ * list checked against what gotenberg:8 can actually produce.
+ */
+test('the archival format must be one gotenberg can produce', function () {
+    postJson('/api/v1/pdf/config', [
+        'pdf_driver' => 'gotenberg',
+        'gotenberg_host' => 'https://pdf.example.com',
+        'gotenberg_pdfa' => 'PDF/A-9z',
+        'pdf_paper_width' => '210mm',
+        'pdf_paper_height' => '297mm',
+        'pdf_orientation' => 'portrait',
+    ])->assertStatus(422)->assertJsonValidationErrors('gotenberg_pdfa');
+});
+
+test('the archival format round trips, and off is a real choice', function () {
+    postJson('/api/v1/pdf/config', [
+        'pdf_driver' => 'gotenberg',
+        'gotenberg_host' => 'https://pdf.example.com',
+        'gotenberg_pdfa' => 'PDF/A-3b',
+        'pdf_paper_width' => '210mm',
+        'pdf_paper_height' => '297mm',
+        'pdf_orientation' => 'portrait',
+    ])->assertOk();
+
+    getJson('/api/v1/pdf/config')->assertOk()->assertJson(['gotenberg_pdfa' => 'PDF/A-3b']);
+
+    postJson('/api/v1/pdf/config', [
+        'pdf_driver' => 'gotenberg',
+        'gotenberg_host' => 'https://pdf.example.com',
+        'gotenberg_pdfa' => '',
+        'pdf_paper_width' => '210mm',
+        'pdf_paper_height' => '297mm',
+        'pdf_orientation' => 'portrait',
+    ])->assertOk();
+
+    getJson('/api/v1/pdf/config')->assertOk()->assertJson(['gotenberg_pdfa' => '']);
+});

--- a/tests/Unit/PdfMetadataTest.php
+++ b/tests/Unit/PdfMetadataTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use App\Models\Company;
+use App\Support\Pdf\DompdfDriver;
+use App\Support\Pdf\GotenbergPdfDriver;
+use App\Support\Pdf\PdfMetadata;
+
+/**
+ * Generated files carried no document properties at all, so an archive of them
+ * showed a column of blank titles. It matters more with PDF/A, whose point is
+ * being readable later by someone who has only the file.
+ */
+test('it builds properties from the document and company', function () {
+    $company = new Company(['name' => 'ACME Corp']);
+
+    expect(PdfMetadata::forDocument('Invoice', 'INV-000042', $company))->toBe([
+        'Title' => 'Invoice INV-000042',
+        'Subject' => 'Invoice',
+        'Author' => 'ACME Corp',
+        'Creator' => config('app.name', 'InvoiceShelf'),
+    ]);
+});
+
+test('missing pieces are left out rather than written as empty strings', function () {
+    $metadata = PdfMetadata::forDocument('Invoice', null, null);
+
+    expect($metadata)->not->toHaveKey('Author')
+        ->and($metadata['Title'])->toBe('Invoice');
+});
+
+test('the gotenberg request carries the metadata', function () {
+    config(['pdf.connections.gotenberg.host' => 'http://gotenberg.example.com:3000']);
+
+    $body = (string) (new GotenbergPdfDriver)->buildRequest(
+        'app.pdf.partials.fonts',
+        ['Title' => 'Invoice INV-000042', 'Author' => 'ACME Corp']
+    )->getBody();
+
+    expect($body)->toContain('metadata')
+        ->and($body)->toContain('Invoice INV-000042')
+        ->and($body)->toContain('ACME Corp');
+});
+
+/**
+ * dompdf reads Title from the <title> element during render(), after any
+ * addInfo() call, so metadata set through the API alone is silently overwritten
+ * by whatever the template happened to put there -- and the two drivers end up
+ * disagreeing about what the file is called.
+ */
+test('dompdf writes the metadata title into the markup so it is not overwritten', function () {
+    $method = new ReflectionMethod(DompdfDriver::class, 'withDocumentTitle');
+
+    $result = $method->invoke(
+        new DompdfDriver,
+        '<html><head><title>whatever the template said</title></head><body></body></html>',
+        'Invoice INV-000042'
+    );
+
+    expect($result)->toContain('<title>Invoice INV-000042</title>')
+        ->and($result)->not->toContain('whatever the template said');
+});
+
+test('a document with no title element gets one', function () {
+    $method = new ReflectionMethod(DompdfDriver::class, 'withDocumentTitle');
+
+    $result = $method->invoke(new DompdfDriver, '<html><head></head><body></body></html>', 'Invoice 42');
+
+    expect($result)->toContain('<title>Invoice 42</title>');
+});
+
+test('a title is escaped rather than injected as markup', function () {
+    $method = new ReflectionMethod(DompdfDriver::class, 'withDocumentTitle');
+
+    $result = $method->invoke(
+        new DompdfDriver,
+        '<html><head><title>x</title></head><body></body></html>',
+        'Invoice <script>alert(1)</script>'
+    );
+
+    expect($result)->not->toContain('<script>')
+        ->and($result)->toContain('&lt;script&gt;');
+});
+
+test('no metadata leaves the markup alone', function () {
+    $method = new ReflectionMethod(DompdfDriver::class, 'withDocumentTitle');
+    $html = '<html><head><title>untouched</title></head><body></body></html>';
+
+    expect($method->invoke(new DompdfDriver, $html, null))->toBe($html);
+});


### PR DESCRIPTION
Stacked on #731.

## Document properties

Generated PDFs carried none, so an archive of them showed a column of blank titles and no author. Title, Subject, Author and Creator now come from the document number and company, on both drivers — dompdf via `addInfo()`, Gotenberg via `metadata()`.

dompdf needed more than the API call. It reads Title from the `<title>` element during `render()`, which happens *after* `addInfo()`:

```php
// vendor/dompdf/dompdf/src/Dompdf.php:787
$title = $this->dom->getElementsByTagName("title");
if ($title->length) {
    $canvas->add_info("Title", trim($title->item(0)->nodeValue));
}
```

So metadata set through the API alone was silently overwritten by whatever the template happened to put there, and the two drivers disagreed about what the file was called. The title is written into the markup as well, escaped. Verified on real output:

| | Title | Author |
|---|---|---|
| dompdf | `Invoice INV-000042` | `ACME Corp` |
| gotenberg | `Invoice INV-000042` | `ACME Corp` |

## PDF/A

New Gotenberg setting: off, PDF/A-1b, PDF/A-2b or PDF/A-3b. PDF/A-3 is what the EU e-invoicing formats expect.

**The plan said verify the stock image supports it before committing to a setting.** It does — LibreOffice inside `gotenberg:8` does the conversion, and the output carries the right conformance level in its XMP:

```
pdfa-PDFA-1b.pdf   PDF version: 1.4   <pdfaid:part>1</pdfaid:part>
pdfa-PDFA-3b.pdf   PDF version: 1.7   <pdfaid:part>3</pdfaid:part>
```

No extra components needed, so this is a setting rather than a documentation problem.

A fixed list rather than free text: the SDK forwards whatever it is given (`ChromiumPdf::pdfa()` does no validation), so an unsupported value would surface only as an HTTP error from the service at render time. Empty is a real choice meaning "ordinary PDF", so it overrides an env default rather than falling through it — same `isset` versus `!empty` trap as the margins.

Gotenberg only; dompdf cannot produce PDF/A.

## Tests

`PdfMetadataTest` — property construction, omitted pieces, the Gotenberg request carrying them, and four cases on the dompdf title rewrite including escaping. Settings round trip and rejection of an unsupported format in `AdminSettingsTest`.

Full suite: 645 passed.
