### PR TITLE
fix(pdf): send the installed fonts to Gotenberg

### DIFF
--- a/app/Services/FontService.php
+++ b/app/Services/FontService.php
@@ -321,6 +321,35 @@ class FontService
      * Used by the PDF fonts partial so dompdf can resolve CJK families
      * via standard CSS — no separate registerFont() dance required.
      */
+    /**
+     * Absolute paths of every installed font file, keyed by filename.
+     *
+     * getInstalledFontFaces() writes those absolute paths straight into
+     * `src: url(...)`, which only works for a renderer sharing this filesystem.
+     * Gotenberg runs Chromium in a separate container, so it needs the files
+     * sent alongside the document — see GotenbergPdfDriver.
+     *
+     * @return array<string, string>
+     */
+    public function getInstalledFontFilePaths(): array
+    {
+        $paths = [];
+
+        foreach (self::FONT_PACKAGES as $package) {
+            if (! $this->isInstalled($package)) {
+                continue;
+            }
+
+            $dir = $this->packageDir($package);
+
+            foreach ($package['files'] as $entry) {
+                $paths[$entry['file']] = $dir.'/'.$entry['file'];
+            }
+        }
+
+        return $paths;
+    }
+
     public function getInstalledFontFaces(): array
     {
         $faces = [];

--- a/app/Support/Pdf/GotenbergPdfDriver.php
+++ b/app/Support/Pdf/GotenbergPdfDriver.php
@@ -2,6 +2,7 @@
 
 namespace App\Support\Pdf;
 
+use App\Services\FontService;
 use App\Support\Net\BlockedUrlException;
 use App\Support\Net\PrivateNetworkGuard;
 use Gotenberg\Gotenberg;
@@ -89,15 +90,55 @@ class GotenbergPdfDriver implements PdfDriver
             $chromium->footer(Stream::string('footer.html', $footer));
         }
 
+        $html = view($template)->render();
+
+        // Fonts must travel with the document; see attachFonts().
+        [$html, $fonts] = $this->attachFonts($html);
+
+        if ($fonts !== []) {
+            $chromium->assets(...$fonts);
+        }
+
         return $chromium->html(
             // The SDK renames this to index.html regardless of what we pass
             // (ChromiumPdf::html()), so name it that way rather than implying
             // a choice we do not have.
-            Stream::string(
-                'index.html',
-                view($template)->render(),
-            )
+            Stream::string('index.html', $html)
         );
+    }
+
+    /**
+     * Send the installed font files alongside the document, and point the
+     * font-face rules at them.
+     *
+     * FontService emits `src: url("/var/www/html/storage/fonts/...")` — an
+     * absolute path on this container's filesystem. dompdf shares that
+     * filesystem so it resolves; Chromium runs inside the Gotenberg container
+     * and cannot see any of it, so every package silently failed to load and
+     * documents fell back to whatever fonts that image happens to ship. The
+     * docs recommend Gotenberg precisely for mixed-script documents, which made
+     * this the wrong way round.
+     *
+     * Gotenberg unpacks assets next to index.html, so a bare filename resolves.
+     * Only fonts actually referenced by the markup are sent, to keep a CJK
+     * package off every request that does not use it.
+     *
+     * @return array{0: string, 1: list<Stream>}
+     */
+    private function attachFonts(string $html): array
+    {
+        $streams = [];
+
+        foreach (app(FontService::class)->getInstalledFontFilePaths() as $filename => $path) {
+            if (! str_contains($html, $path) || ! is_readable($path)) {
+                continue;
+            }
+
+            $html = str_replace($path, $filename, $html);
+            $streams[] = Stream::path($path, $filename);
+        }
+
+        return [$html, $streams];
     }
 
     /**

--- a/tests/Unit/GotenbergFontDeliveryTest.php
+++ b/tests/Unit/GotenbergFontDeliveryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Services\FontService;
+use App\Support\Pdf\GotenbergPdfDriver;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\View;
+
+/**
+ * FontService writes absolute host paths into the @font-face rules. dompdf shares
+ * that filesystem so they resolve; Chromium runs inside the Gotenberg container
+ * and cannot see any of it, so every installed package silently failed to load
+ * and documents fell back to whatever fonts that image ships. The docs recommend
+ * Gotenberg specifically for mixed-script documents, which made this the wrong
+ * way round.
+ */
+beforeEach(function () {
+    config(['pdf.connections.gotenberg.host' => 'http://gotenberg.example.com:3000']);
+
+    $this->views = sys_get_temp_dir().'/is-fonts-'.uniqid();
+    File::ensureDirectoryExists($this->views);
+    View::addNamespace('fonttest', $this->views);
+
+    $this->fonts = app(FontService::class)->getInstalledFontFilePaths();
+});
+
+afterEach(function () {
+    File::deleteDirectory($this->views);
+});
+
+/**
+ * Distinct view names per case: Blade caches compiled views by path, so reusing
+ * one filename can silently render the previous case's markup.
+ */
+function fontRequestBody(string $markup, string $dir, string $name = 'doc'): string
+{
+    File::put("{$dir}/{$name}.blade.php", $markup);
+    View::getFinder()->flush();
+
+    return (string) (new GotenbergPdfDriver)->buildRequest("fonttest::{$name}")->getBody();
+}
+
+test('a document using the font partial gets the files sent with it', function () {
+    expect($this->fonts)->not->toBeEmpty('no bundled fonts installed to test against');
+
+    $body = fontRequestBody(
+        '<html><head>@include("app.pdf.partials.fonts")</head><body>x</body></html>',
+        $this->views,
+        'with-fonts'
+    );
+
+    $filename = array_key_first($this->fonts);
+
+    expect($body)->toContain($filename);
+});
+
+/**
+ * Gotenberg unpacks assets next to index.html, so the rule has to name the file
+ * rather than a path this container happens to have.
+ */
+test('the absolute host path is rewritten out of the markup', function () {
+    $body = fontRequestBody(
+        '<html><head>@include("app.pdf.partials.fonts")</head><body>x</body></html>',
+        $this->views,
+        'rewritten'
+    );
+
+    foreach ($this->fonts as $path) {
+        expect($body)->not->toContain($path);
+    }
+});
+
+/**
+ * A CJK package is several megabytes, so it should not ride along on a request
+ * whose document never mentions it.
+ */
+test('fonts the document does not reference are not sent', function () {
+    $body = fontRequestBody('<html><body>no font rules here</body></html>', $this->views, 'plain');
+
+    foreach ($this->fonts as $filename => $path) {
+        expect($body)->not->toContain($filename);
+    }
+});
+
+test('the font files themselves are attached, not just referenced', function () {
+    $withFonts = fontRequestBody(
+        '<html><head>@include("app.pdf.partials.fonts")</head><body>x</body></html>',
+        $this->views,
+        'payload-with'
+    );
+    $without = fontRequestBody('<html><body>x</body></html>', $this->views, 'payload-without');
+
+    // The difference is the font payload, which is far larger than the markup.
+    expect(strlen($withFonts))->toBeGreaterThan(strlen($without) + 100_000);
+});


### PR DESCRIPTION
Stacked on #732.

## The bug

`FontService::getInstalledFontFaces()` writes absolute host paths into the `@font-face` rules:

```css
src: url("/var/www/html/storage/fonts/NotoSansSC-Regular.ttf") format('truetype');
```

dompdf shares that filesystem, so they resolve. **Chromium runs inside the Gotenberg container and cannot see any of it**, so every installed font package silently failed to load.

That is the wrong way round: `docs/guide/pdf-generation.md` recommends Gotenberg *specifically* for mixed-script documents. It appeared to work only by accident — Chromium's own bundled fonts cover more scripts than dompdf's one-font-for-everything behaviour — but nothing the operator installed through **Settings → Font Packages** was reaching it.

## The fix

The font files travel with the document as Gotenberg assets, and the rules are rewritten to name them. Gotenberg unpacks assets next to `index.html`, so a bare filename resolves.

Only fonts the markup actually references are sent — a CJK package is several megabytes and has no business riding along on a request that never mentions it.

## Confirmed against a stock gotenberg:8

Reading the fonts back out of the rendered PDF with `pdffonts`:

```
before   AAAAAA+LiberationSerif      <- Gotenberg's fallback
after    AAAAAA+NotoSans-Regular     <- the app's own font
```

## Tests

`GotenbergFontDeliveryTest` — the files are sent, the absolute path is gone from the markup, unreferenced fonts are not attached, and the payload actually grows by the font data rather than only mentioning the names.

Full suite: 649 passed.
