### PR TITLE
Add compound tax support

### DIFF
--- a/app/Domains/Sales/Application/DocumentItemService.php
+++ b/app/Domains/Sales/Application/DocumentItemService.php
@@ -65,6 +65,11 @@ class DocumentItemService
 
             if (array_key_exists('taxes', $item) && $item['taxes']) {
                 foreach ($item['taxes'] as $tax) {
+                    if (empty($tax['tax_type_id'])) {
+                        // UI placeholder row for per-item tax mode; never persist.
+                        continue;
+                    }
+
                     $tax['company_id'] = $document->company_id;
                     $tax['exchange_rate'] = $document->exchange_rate;
                     $tax['currency_id'] = $document->currency_id;

--- a/app/Domains/Taxation/Http/Requests/TaxTypeRequest.php
+++ b/app/Domains/Taxation/Http/Requests/TaxTypeRequest.php
@@ -45,6 +45,7 @@ class TaxTypeRequest extends FormRequest
             ],
             'compound_tax' => [
                 'nullable',
+                'boolean',
             ],
             'collective_tax' => [
                 'nullable',

--- a/database/factories/TaxFactory.php
+++ b/database/factories/TaxFactory.php
@@ -32,7 +32,7 @@ class TaxFactory extends Factory
             },
             'company_id' => User::find(1)->companies()->first()->id,
             'amount' => $this->faker->randomDigitNotNull(),
-            'compound_tax' => $this->faker->randomDigitNotNull(),
+            'compound_tax' => false,
             'base_amount' => $this->faker->randomDigitNotNull(),
             'currency_id' => Currency::where('name', 'US Dollar')->first()->id,
         ];

--- a/lang/en.json
+++ b/lang/en.json
@@ -1416,6 +1416,7 @@
       "tax_per_item": "Tax Per Item",
       "tax_name": "Tax Name",
       "compound_tax": "Compound Tax",
+      "compound_tax_description": "Calculated on the subtotal after discount plus all non-compound taxes.",
       "amount": "Amount",
       "percent": "Percent",
       "fixed_amount": "Fixed Amount",

--- a/resources/scripts/features/company/settings/components/TaxTypeModal.vue
+++ b/resources/scripts/features/company/settings/components/TaxTypeModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
   required,
@@ -26,6 +26,7 @@ interface TaxTypeForm {
   transaction_type: TaxTypeTransactionType
   percent: number
   fixed_amount: number
+  compound_tax: boolean
   description: string
 }
 
@@ -48,6 +49,7 @@ const currentTaxType = ref<TaxTypeForm>({
   transaction_type: 'sales',
   percent: 0,
   fixed_amount: 0,
+  compound_tax: false,
   description: '',
 })
 
@@ -55,6 +57,12 @@ const defaultCurrency = computed(() => companyStore.selectedCompanyCurrency)
 
 const modalActive = computed<boolean>(
   () => modalStore.active && modalStore.componentName === 'TaxTypeModal'
+)
+
+const showCompoundToggle = computed<boolean>(
+  () =>
+    currentTaxType.value.calculation_type === 'percentage' &&
+    currentTaxType.value.transaction_type === 'sales'
 )
 
 const rules = computed(() => ({
@@ -98,6 +106,18 @@ const fixedAmount = computed<number>({
   },
 })
 
+watch(
+  [
+    () => currentTaxType.value.calculation_type,
+    () => currentTaxType.value.transaction_type,
+  ],
+  () => {
+    if (!showCompoundToggle.value) {
+      currentTaxType.value.compound_tax = false
+    }
+  }
+)
+
 async function setInitialData(): Promise<void> {
   if (modalStore.data && typeof modalStore.data === 'number') {
     isEdit.value = true
@@ -111,6 +131,7 @@ async function setInitialData(): Promise<void> {
         transaction_type: tax.transaction_type,
         percent: tax.percent,
         fixed_amount: tax.fixed_amount,
+        compound_tax: tax.compound_tax ?? false,
         description: tax.description ?? '',
       }
     }
@@ -138,6 +159,7 @@ async function submitTaxTypeData(): Promise<void> {
       fixed_amount: currentTaxType.value.fixed_amount,
       calculation_type: currentTaxType.value.calculation_type,
       transaction_type: currentTaxType.value.transaction_type,
+      compound_tax: currentTaxType.value.compound_tax,
       description: currentTaxType.value.description || null,
     }
 
@@ -176,6 +198,7 @@ function resetForm(): void {
     transaction_type: 'sales',
     percent: 0,
     fixed_amount: 0,
+    compound_tax: false,
     description: '',
   }
 }
@@ -309,6 +332,15 @@ function closeTaxTypeModal(): void {
             required
           >
             <BaseMoney v-model="fixedAmount" :currency="defaultCurrency" />
+          </BaseInputGroup>
+
+          <BaseInputGroup
+            v-if="showCompoundToggle"
+            :label="$t('tax_types.compound_tax')"
+            :help-text="$t('settings.tax_types.compound_tax_description')"
+            variant="horizontal"
+          >
+            <BaseSwitch v-model="currentTaxType.compound_tax" />
           </BaseInputGroup>
 
           <BaseInputGroup

--- a/resources/scripts/features/company/settings/views/TaxTypesView.vue
+++ b/resources/scripts/features/company/settings/views/TaxTypesView.vue
@@ -195,6 +195,9 @@ function openTaxModal(): void {
     >
       <template #cell-calculation_type="{ row }">
         {{ $t(`settings.tax_types.${row.data.calculation_type}`) }}
+        <BaseBadge v-if="row.data.compound_tax" class="ml-2">
+          {{ $t('tax_types.compound_tax') }}
+        </BaseBadge>
       </template>
 
       <template #cell-amount="{ row }">

--- a/resources/scripts/features/shared/document-form/DocumentItemRow.vue
+++ b/resources/scripts/features/shared/document-form/DocumentItemRow.vue
@@ -171,11 +171,12 @@
                 :tax-data="tax"
                 :taxes="itemData.taxes ?? []"
                 :discounted-total="total"
-                :total-tax="totalSimpleTax"
+                :total-simple-tax="totalSimpleTax"
                 :total="subtotal"
                 :currency="currency"
                 :update-items="syncItemToStore"
-                :ability="'create-invoice'"
+                :tax-types="taxTypes"
+                :can-add-tax="canAddTax"
                 :store="store"
                 :store-prop="storeProp"
                 :discount="discount"
@@ -199,6 +200,7 @@ import DocumentItemRowTax from './DocumentItemRowTax.vue'
 import DragIcon from '@/scripts/components/icons/DragIcon.vue'
 import { generateClientId } from '../../../utils'
 import type { Currency } from '../../../types/domain/currency'
+import type { TaxType } from '../../../types/domain/tax'
 import type { DocumentItem, DocumentFormData, DocumentTax } from './use-document-calculations'
 
 interface Props {
@@ -215,6 +217,8 @@ interface Props {
   currency: Currency | Record<string, unknown>
   invoiceItems: DocumentItem[]
   itemValidationScope?: string
+  taxTypes?: TaxType[]
+  canAddTax?: boolean
 }
 
 interface Emits {
@@ -227,6 +231,8 @@ const props = withDefaults(defineProps<Props>(), {
   type: '',
   loading: false,
   itemValidationScope: '',
+  taxTypes: () => [],
+  canAddTax: false,
 })
 
 const emit = defineEmits<Emits>()
@@ -286,16 +292,33 @@ const showRemoveButton = computed<boolean>(() => {
   return formData.value.items.length > 1
 })
 
+// Base handed down to the tax rows: only the non-compound taxes count, so a
+// compound row can never widen its own base through this value.
 const totalSimpleTax = computed<number>(() => {
   const taxes = props.itemData.taxes ?? []
   return Math.round(
     taxes.reduce((sum: number, tax: Partial<DocumentTax>) => {
+      if (tax.compound_tax) {
+        return sum
+      }
       return sum + (tax.amount ?? 0)
     }, 0),
   )
 })
 
-const totalTax = computed<number>(() => totalSimpleTax.value)
+const totalCompoundTax = computed<number>(() => {
+  const taxes = props.itemData.taxes ?? []
+  return Math.round(
+    taxes.reduce((sum: number, tax: Partial<DocumentTax>) => {
+      if (tax.compound_tax) {
+        return sum + (tax.amount ?? 0)
+      }
+      return sum
+    }, 0),
+  )
+})
+
+const totalTax = computed<number>(() => totalSimpleTax.value + totalCompoundTax.value)
 
 const companyCurrency = computed(() => companyStore.selectedCompanyCurrency)
 
@@ -436,6 +459,7 @@ function syncItemToStore(): void {
     total: total.value,
     sub_total: subtotal.value,
     totalSimpleTax: totalSimpleTax.value,
+    totalCompoundTax: totalCompoundTax.value,
     totalTax: totalTax.value,
     tax: totalTax.value,
     taxes: [...itemTaxes],

--- a/resources/scripts/features/shared/document-form/DocumentItemRowTax.vue
+++ b/resources/scripts/features/shared/document-form/DocumentItemRowTax.vue
@@ -37,6 +37,9 @@
           <template v-else>
             {{ option.percent }} %
           </template>
+          <BaseBadge v-if="option.compound_tax" class="ml-2 text-xs">
+            {{ $t('tax_types.compound_tax') }}
+          </BaseBadge>
         </template>
 
         <template v-if="canAddTax" #action>
@@ -77,16 +80,9 @@ import { useModalStore } from '../../../stores/modal.store'
 import type { TaxType } from '../../../types/domain/tax'
 import type { Currency } from '../../../types/domain/currency'
 import type { DocumentFormData, DocumentTax } from './use-document-calculations'
-
-declare global {
-  interface Window {
-    __taxTypes?: TaxType[]
-    __userHasAbility?: (ability: string) => boolean
-  }
-}
+import { calcTaxAmount } from './use-document-calculations'
 
 interface Props {
-  ability: string
   store: Record<string, unknown>
   storeProp: string
   itemIndex: number
@@ -94,10 +90,13 @@ interface Props {
   taxData: DocumentTax
   taxes: DocumentTax[]
   total: number
-  totalTax: number
+  /** Sum of the item's non-compound tax amounts, i.e. the compound base widener. */
+  totalSimpleTax: number
   discountedTotal: number
   currency: Currency | Record<string, unknown>
   updateItems: () => void
+  taxTypes?: TaxType[]
+  canAddTax?: boolean
   discount?: number
 }
 
@@ -107,7 +106,8 @@ interface Emits {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  ability: '',
+  taxTypes: () => [],
+  canAddTax: false,
   discount: 0,
 })
 
@@ -116,23 +116,13 @@ const emit = defineEmits<Emits>()
 const { t } = useI18n()
 const modalStore = useModalStore()
 
-const taxTypes = computed<TaxType[]>(() => {
-  return (window.__taxTypes ?? []).filter(
-    (taxType) => taxType.transaction_type === 'sales',
-  )
-})
-
-const canAddTax = computed(() => {
-  return window.__userHasAbility?.(props.ability) ?? false
-})
-
 const selectedTax = ref<TaxType | null>(null)
 const localTax = reactive<DocumentTax>({ ...props.taxData })
 
 const storeData = computed(() => props.store[props.storeProp] as DocumentFormData)
 
 const filteredTypes = computed<(TaxType & { disabled?: boolean })[]>(() => {
-  const clonedTypes = taxTypes.value.map((a) => ({ ...a, disabled: false }))
+  const clonedTypes = props.taxTypes.map((a) => ({ ...a, disabled: false }))
 
   return clonedTypes.map((taxType) => {
     const found = props.taxes.find((tax) => tax.tax_type_id === taxType.id)
@@ -141,27 +131,52 @@ const filteredTypes = computed<(TaxType & { disabled?: boolean })[]>(() => {
   })
 })
 
+/**
+ * The item's taxable base, shared by every tax branch.
+ *
+ * With a per-item discount the item total is already net of it. With a
+ * document-level discount the item carries its proportional share of that
+ * discount instead.
+ */
+const effectiveBase = computed<number>(() => {
+  if (storeData.value.discount_per_item === 'YES') {
+    return props.discountedTotal
+  }
+
+  const modelDiscount = storeData.value.discount ?? 0
+
+  if (modelDiscount <= 0) {
+    return props.discountedTotal
+  }
+
+  const itemsTotal = storeData.value.items.reduce(
+    (sum: number, item) => sum + (item.total ?? 0),
+    0,
+  )
+
+  if (!itemsTotal) {
+    return props.discountedTotal
+  }
+
+  const proportion = parseFloat((props.discountedTotal / itemsTotal).toFixed(2))
+  const discount =
+    storeData.value.discount_type === 'fixed'
+      ? modelDiscount * 100
+      : (itemsTotal * modelDiscount) / 100
+
+  return props.discountedTotal - Math.round(discount * proportion)
+})
+
 const taxAmount = computed<number>(() => {
-  if (localTax.calculation_type === 'fixed') {
-    return localTax.fixed_amount
-  }
-
-  if (props.discountedTotal) {
-    const taxPerItemEnabled = storeData.value.tax_per_item === 'YES'
-    const discountPerItemEnabled = storeData.value.discount_per_item === 'YES'
-
-    if (taxPerItemEnabled && !discountPerItemEnabled) {
-      return getTaxAmount()
-    }
-    if (storeData.value.tax_included) {
-      return Math.round(
-        props.discountedTotal -
-          props.discountedTotal / (1 + (localTax.percent ?? 0) / 100),
-      )
-    }
-    return Math.round((props.discountedTotal * (localTax.percent ?? 0)) / 100)
-  }
-  return 0
+  return calcTaxAmount(
+    effectiveBase.value,
+    localTax.percent,
+    localTax.fixed_amount,
+    localTax.calculation_type,
+    storeData.value.tax_included ?? false,
+    localTax.compound_tax ?? false,
+    props.totalSimpleTax,
+  )
 })
 
 watch(
@@ -169,8 +184,9 @@ watch(
   () => updateRowTax(),
 )
 
+// A sibling simple tax landing later widens this row's base when it is compound.
 watch(
-  () => props.totalTax,
+  () => props.totalSimpleTax,
   () => updateRowTax(),
 )
 
@@ -179,11 +195,18 @@ watch(
   () => updateRowTax(),
 )
 
-// Initialize selected tax if editing
-if (props.taxData.tax_type_id > 0) {
-  selectedTax.value =
-    taxTypes.value.find((_type) => _type.id === props.taxData.tax_type_id) ?? null
-}
+// Resolve the selected tax type when editing. The list is fetched by the parent
+// table, so it usually arrives after this row has been set up.
+watch(
+  () => props.taxTypes,
+  (types) => {
+    if (localTax.tax_type_id > 0) {
+      selectedTax.value =
+        types.find((_type) => _type.id === localTax.tax_type_id) ?? selectedTax.value
+    }
+  },
+  { immediate: true },
+)
 
 updateRowTax()
 
@@ -194,6 +217,7 @@ function onSelectTax(val: TaxType): void {
     val.calculation_type === 'fixed' ? val.fixed_amount : 0
   localTax.tax_type_id = val.id
   localTax.name = val.name
+  localTax.compound_tax = val.compound_tax ?? false
 
   updateRowTax()
 }
@@ -229,43 +253,9 @@ function removeTax(index: number): void {
   const store = props.store as Record<string, Record<string, unknown>>
   const formData = store[props.storeProp] as DocumentFormData
   formData.items[props.itemIndex].taxes?.splice(index, 1)
-  const item = formData.items[props.itemIndex]
-  item.tax = 0
-  item.totalTax = 0
-}
 
-function getTaxAmount(): number {
-  if (localTax.calculation_type === 'fixed') {
-    return localTax.fixed_amount
-  }
-
-  let itemsTotal = 0
-  let discount = 0
-  const itemTotal = props.discountedTotal
-  const modelDiscount = storeData.value.discount ?? 0
-  const type = storeData.value.discount_type
-  let discountedTotal = props.discountedTotal
-
-  if (modelDiscount > 0) {
-    storeData.value.items.forEach((item) => {
-      itemsTotal += item.total ?? 0
-    })
-    const proportion = parseFloat((itemTotal / itemsTotal).toFixed(2))
-    discount =
-      type === 'fixed'
-        ? modelDiscount * 100
-        : (itemsTotal * modelDiscount) / 100
-    const itemDiscount = Math.round(discount * proportion)
-    discountedTotal = itemTotal - itemDiscount
-  }
-
-  if (storeData.value.tax_included) {
-    return Math.round(
-      discountedTotal -
-        discountedTotal / (1 + (localTax.percent ?? 0) / 100),
-    )
-  }
-
-  return Math.round((discountedTotal * (localTax.percent ?? 0)) / 100)
+  // Re-sync the item so the remaining rows re-base off the new simple total
+  // instead of leaving stale `tax` / `totalTax` values behind.
+  props.updateItems()
 }
 </script>

--- a/resources/scripts/features/shared/document-form/DocumentItemsTable.vue
+++ b/resources/scripts/features/shared/document-form/DocumentItemsTable.vue
@@ -92,6 +92,8 @@
             :currency="defaultCurrency"
             :item-validation-scope="itemValidationScope"
             :invoice-items="formData.items"
+            :tax-types="availableTaxTypes"
+            :can-add-tax="canAddTax"
             :store="store"
             :store-prop="storeProp"
           />
@@ -110,11 +112,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import draggable from 'vuedraggable'
 import DocumentItemRow from './DocumentItemRow.vue'
 import ItemModal from '@/scripts/features/company/items/components/ItemModal.vue'
+import { useUserStore } from '../../../stores/user.store'
+import { taxTypeService } from '../../../api/services/tax-type.service'
+import { ABILITIES } from '../../../config/abilities'
 import type { Currency } from '../../../types/domain/currency'
+import type { TaxType } from '../../../types/domain/tax'
 import type { DocumentFormData } from './use-document-calculations'
 
 interface Props {
@@ -132,6 +138,25 @@ const props = withDefaults(defineProps<Props>(), {
   isLoading: false,
   itemValidationScope: '',
   taxIncludedSetting: 'NO',
+})
+
+const userStore = useUserStore()
+const availableTaxTypes = ref<TaxType[]>([])
+
+const canAddTax = computed<boolean>(() => {
+  return userStore.hasAbilities(ABILITIES.CREATE_TAX_TYPE)
+})
+
+onMounted(async () => {
+  try {
+    const response = await taxTypeService.list({
+      limit: 'all',
+      transaction_type: 'sales',
+    })
+    availableTaxTypes.value = response.data
+  } catch {
+    // Silently fail
+  }
 })
 
 const formData = computed<DocumentFormData>(() => {

--- a/resources/scripts/features/shared/document-form/DocumentTotals.vue
+++ b/resources/scripts/features/shared/document-form/DocumentTotals.vue
@@ -241,6 +241,7 @@ import { ABILITIES } from '../../../config/abilities'
 import type { Currency } from '../../../types/domain/currency'
 import type { TaxType } from '../../../types/domain/tax'
 import type { DocumentFormData, DocumentTax, DocumentStore, DocumentItem } from './use-document-calculations'
+import { calcTaxAmount } from './use-document-calculations'
 
 interface Props {
   store: DocumentStore & {
@@ -316,6 +317,13 @@ watch(
   { deep: true },
 )
 
+watch(
+  () => formData.value.tax_included,
+  () => {
+    recalculateGlobalTaxes()
+  },
+)
+
 const totalDiscount = computed<number>({
   get: () => formData.value.discount,
   set: (newValue: number) => {
@@ -341,6 +349,7 @@ interface AggregatedTax {
   name: string
   calculation_type: string | null
   fixed_amount: number
+  compound_tax: boolean
 }
 
 const itemWiseTaxes = computed<AggregatedTax[]>(() => {
@@ -359,6 +368,7 @@ const itemWiseTaxes = computed<AggregatedTax[]>(() => {
             name: tax.name ?? '',
             calculation_type: tax.calculation_type ?? null,
             fixed_amount: tax.fixed_amount ?? 0,
+            compound_tax: tax.compound_tax ?? false,
           })
         }
       })
@@ -382,11 +392,39 @@ function recalculateGlobalTaxes(): void {
   if (formData.value.tax_per_item === 'YES') return
 
   const subtotalWithDiscount = props.store.getSubtotalWithDiscount
+  const taxIncluded = formData.value.tax_included ?? false
+
+  // Pass 1: simple (non-compound) taxes are charged on the discounted subtotal.
+  let simpleTotal = 0
   formData.value.taxes.forEach((tax: DocumentTax) => {
+    if (tax.compound_tax) return
     if (tax.calculation_type === 'percentage' && tax.percent) {
-      tax.amount = Math.round((subtotalWithDiscount * tax.percent) / 100)
+      tax.amount = calcTaxAmount(
+        subtotalWithDiscount,
+        tax.percent,
+        null,
+        'percentage',
+        taxIncluded,
+      )
     }
-    // Fixed taxes keep their amount as-is
+    // Fixed taxes keep their amount as-is, but still count toward the compound base
+    simpleTotal += tax.amount ?? 0
+  })
+
+  // Pass 2: compound taxes are charged on the discounted subtotal plus the simple taxes.
+  formData.value.taxes.forEach((tax: DocumentTax) => {
+    if (!tax.compound_tax) return
+    if (tax.calculation_type === 'percentage' && tax.percent) {
+      tax.amount = calcTaxAmount(
+        subtotalWithDiscount,
+        tax.percent,
+        null,
+        'percentage',
+        taxIncluded,
+        true,
+        simpleTotal,
+      )
+    }
   })
 }
 
@@ -404,18 +442,15 @@ function selectPercentage(): void {
 }
 
 function onSelectTax(selectedTax: TaxType): void {
-  let amount = 0
-  if (
-    selectedTax.calculation_type === 'percentage' &&
-    props.store.getSubtotalWithDiscount &&
-    selectedTax.percent
-  ) {
-    amount = Math.round(
-      (props.store.getSubtotalWithDiscount * selectedTax.percent) / 100,
-    )
-  } else if (selectedTax.calculation_type === 'fixed') {
-    amount = selectedTax.fixed_amount
-  }
+  const amount = calcTaxAmount(
+    props.store.getSubtotalWithDiscount,
+    selectedTax.percent,
+    selectedTax.fixed_amount,
+    selectedTax.calculation_type,
+    formData.value.tax_included ?? false,
+    selectedTax.compound_tax ?? false,
+    props.store.getTotalSimpleTax,
+  )
 
   const data: DocumentTax = {
     id: generateClientId(),
@@ -431,6 +466,10 @@ function onSelectTax(selectedTax: TaxType): void {
   props.store.$patch((state: Record<string, unknown>) => {
     ;(state[props.storeProp] as DocumentFormData).taxes.push({ ...data })
   })
+
+  // Adding a simple tax widens the base of any compound tax already present,
+  // so the insertion order must not matter.
+  recalculateGlobalTaxes()
 }
 
 function updateTax(data: DocumentTax): void {
@@ -445,5 +484,8 @@ function removeTax(id: number | string): void {
   props.store.$patch((state: Record<string, unknown>) => {
     ;(state[props.storeProp] as DocumentFormData).taxes.splice(index, 1)
   })
+
+  // Removing a simple tax shrinks the base of any remaining compound tax.
+  recalculateGlobalTaxes()
 }
 </script>

--- a/resources/scripts/features/shared/document-form/TaxSelectPopup.vue
+++ b/resources/scripts/features/shared/document-form/TaxSelectPopup.vue
@@ -64,6 +64,9 @@
                         </template>
                         <template v-else>
                           {{ taxType.percent }} %
+                          <BaseBadge v-if="taxType.compound_tax" class="text-xs">
+                            {{ $t('tax_types.compound_tax') }}
+                          </BaseBadge>
                         </template>
                       </label>
                     </div>

--- a/resources/scripts/features/shared/document-form/use-document-calculations.ts
+++ b/resources/scripts/features/shared/document-form/use-document-calculations.ts
@@ -161,18 +161,36 @@ export function calcItemTotal(subtotal: number, discountVal: number): number {
   return subtotal - discountVal
 }
 
-/** Calculate tax amount for a given total and tax config */
+/**
+ * Calculate tax amount for a given total and tax config.
+ *
+ * A compound tax is charged on the base plus every simple (non-compound) tax
+ * already applied, and is never backed out of a tax-inclusive total.
+ *
+ * @param total Base amount in cents (document subtotal after discount, or an item total after discount)
+ * @param percent Percentage rate, when the tax is percentage based
+ * @param fixedAmount Flat amount in cents, when the tax is fixed
+ * @param calculationType `'fixed'` or `'percentage'`
+ * @param taxIncluded Whether the base already includes the tax (back it out)
+ * @param compoundTax Whether the tax is charged on top of the simple taxes
+ * @param simpleTaxTotal Sum of the non-compound tax amounts in cents
+ */
 export function calcTaxAmount(
   total: number,
   percent: number | null,
   fixedAmount: number | null,
   calculationType: string | null,
   taxIncluded: boolean | null,
+  compoundTax = false,
+  simpleTaxTotal = 0,
 ): number {
   if (calculationType === 'fixed' && fixedAmount != null) {
     return fixedAmount
   }
   if (!total || !percent) return 0
+  if (compoundTax) {
+    return Math.round(((total + simpleTaxTotal) * percent) / 100)
+  }
   if (taxIncluded) {
     return Math.round(total - total / (1 + percent / 100))
   }

--- a/tests/Feature/Admin/InvoiceTest.php
+++ b/tests/Feature/Admin/InvoiceTest.php
@@ -528,6 +528,51 @@ test('create invoice with tax per item', function () {
     ]);
 });
 
+test('create invoice with tax per item ignores empty placeholder tax row', function () {
+    // The frontend always keeps one empty placeholder tax row per item in
+    // per-item tax mode. It must be skipped instead of reaching the DB.
+    $stubTax = [
+        'id' => 999,
+        'tax_type_id' => 0,
+        'name' => '',
+        'amount' => 0,
+        'percent' => null,
+        'calculation_type' => null,
+        'fixed_amount' => 0,
+        'compound_tax' => false,
+    ];
+
+    $realTax = Tax::factory()->raw();
+
+    $invoice = Invoice::factory()
+        ->raw([
+            'tax_per_item' => 'YES',
+            'items' => [
+                InvoiceItem::factory()->raw([
+                    'taxes' => [$realTax, $stubTax],
+                ]),
+            ],
+        ]);
+
+    $response = postJson('api/v1/invoices', $invoice);
+
+    $response->assertOk();
+
+    $this->assertDatabaseHas('invoices', [
+        'invoice_number' => $invoice['invoice_number'],
+        'customer_id' => $invoice['customer_id'],
+    ]);
+
+    $this->assertDatabaseHas('taxes', [
+        'tax_type_id' => $realTax['tax_type_id'],
+        'amount' => $realTax['amount'],
+    ]);
+
+    $this->assertDatabaseMissing('taxes', [
+        'tax_type_id' => 0,
+    ]);
+});
+
 test('create invoice with EUR currency', function () {
     $invoice = Invoice::factory()
         ->raw([

--- a/tests/Feature/Admin/TaxTypeTest.php
+++ b/tests/Feature/Admin/TaxTypeTest.php
@@ -179,3 +179,82 @@ test('rejects unknown transaction types', function () {
         ->assertUnprocessable()
         ->assertJsonValidationErrors('transaction_type');
 });
+
+test('creates a compound tax type', function () {
+    $taxType = TaxType::factory()->raw([
+        'compound_tax' => true,
+    ]);
+
+    postJson('api/v1/tax-types', $taxType)
+        ->assertStatus(201)
+        ->assertJsonPath('data.compound_tax', true);
+
+    $this->assertDatabaseHas('tax_types', [
+        'name' => $taxType['name'],
+        'compound_tax' => 1,
+    ]);
+});
+
+test('creates a non-compound tax type when compound_tax is explicitly false', function () {
+    $taxType = TaxType::factory()->raw([
+        'compound_tax' => false,
+    ]);
+
+    postJson('api/v1/tax-types', $taxType)
+        ->assertStatus(201)
+        ->assertJsonPath('data.compound_tax', false);
+
+    $this->assertDatabaseHas('tax_types', [
+        'name' => $taxType['name'],
+        'compound_tax' => 0,
+    ]);
+});
+
+test('updates a tax type to explicitly disable compound tax', function () {
+    $taxType = TaxType::factory()->create([
+        'compound_tax' => true,
+    ]);
+
+    $payload = TaxType::factory()->raw([
+        'compound_tax' => false,
+    ]);
+
+    putJson("api/v1/tax-types/{$taxType->id}", $payload)
+        ->assertOk()
+        ->assertJsonPath('data.compound_tax', false);
+
+    $this->assertDatabaseHas('tax_types', [
+        'id' => $taxType->id,
+        'compound_tax' => 0,
+    ]);
+});
+
+test('preserves compound tax when updates omit the key', function () {
+    $taxType = TaxType::factory()->create([
+        'compound_tax' => true,
+    ]);
+
+    $payload = TaxType::factory()->raw();
+    // TaxType::factory()->raw() defaults compound_tax to 0 — unset it so the
+    // request omits the key entirely, instead of silently sending false.
+    unset($payload['compound_tax']);
+
+    putJson("api/v1/tax-types/{$taxType->id}", $payload)
+        ->assertOk()
+        ->assertJsonPath('data.compound_tax', true);
+
+    $this->assertDatabaseHas('tax_types', [
+        'id' => $taxType->id,
+        'compound_tax' => 1,
+    ]);
+});
+
+test('rejects non-boolean compound_tax values', function () {
+    $taxType = TaxType::factory()->raw([
+        'compound_tax' => 'not-a-bool',
+    ]);
+
+    postJson('api/v1/tax-types', $taxType)
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('compound_tax');
+});

--- a/tests/Unit/DocumentTotalsTest.php
+++ b/tests/Unit/DocumentTotalsTest.php
@@ -76,3 +76,14 @@ test('supports negative quantities', function () {
 
     expect($totals['sub_total'])->toBe(-150)->and($totals['total'])->toBe(-150);
 });
+
+test('sums a compound tax line just like any other document-level tax line', function () {
+    $totals = DocumentTotals::compute(
+        [['price' => 10000, 'quantity' => 1]],
+        [['amount' => 1900], ['amount' => 119, 'compound_tax' => true]],
+        0, 'NO', false, 'NO'
+    );
+
+    expect($totals['tax'])->toBe(2019)
+        ->and($totals['total'])->toBe(12019);
+});


### PR DESCRIPTION
## Summary

Adds support for **compound taxes** on sales documents. A compound tax is calculated after ordinary taxes, allowing InvoiceShelf to model charges that apply to the tax-inclusive amount rather than only the net subtotal.

For example, a 1% cash-payment levy applied after 19% VAT is calculated as:

| Description | Amount |
| --- | ---: |
| Net amount | 100.00 |
| VAT (19%) | 19.00 |
| Cash levy (1% of 119.00) | 1.19 |
| **Total** | **120.19** |

The tax is selected on the document like any other tax type. This PR does not automatically detect the customer's payment method.

## What changed

- Add a **Compound Tax** option for percentage-based sales taxes.
- Show a compound-tax badge in tax settings and document tax selectors.
- Calculate ordinary taxes first and compound taxes second, regardless of the order in which they were selected.
- Support compound taxes in both document-level and per-item tax modes.
- Apply quantity and discount changes consistently when recalculating the compound-tax base.
- Keep multiple compound taxes on the same base instead of compounding them on one another.
- Validate and persist the compound-tax setting through the API.
- Fix the per-item tax picker and prevent empty placeholder rows from being saved as taxes.
- Recalculate totals correctly when tax-inclusive mode changes or a per-item tax is removed.

## Verification

- Automated coverage for tax-type create/update behavior, document totals, and placeholder-row handling.
- Full PHP test suite and formatting checks.
- Frontend lint and production build.
- Browser verification of document-level and per-item tax flows, selection-order independence, quantity changes, discounts, saving, editing, and PDF output.

