### PR TITLE
Add RTL layout support for Arabic and Persian

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "watch": "vite build --watch",
     "build": "vite build",
     "serve": "vite preview",
-    "test": "eslint ./resources/scripts"
+    "test": "eslint ./resources/scripts",
+    "test:unit": "node --test tests/JavaScript/*.test.js"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.10",

--- a/resources/scripts/InvoiceShelf.js
+++ b/resources/scripts/InvoiceShelf.js
@@ -1,4 +1,4 @@
-import { createApp } from 'vue'
+import { createApp, watch } from 'vue'
 import App from '@/scripts/App.vue'
 import { createI18n } from 'vue-i18n'
 import messages from '/lang/locales'
@@ -8,6 +8,7 @@ import utils from '@/scripts/helpers/utilities.js'
 import _ from 'lodash'
 import { VTooltip } from 'v-tooltip'
 import { setI18nLanguage } from '@/scripts/helpers/language-loader.js'
+import { syncDocumentLocale } from '@/scripts/helpers/document-locale.js'
 
 const app = createApp(App)
 
@@ -59,6 +60,10 @@ export default class InvoiceShelf {
     })
 
     window.i18n = this.i18n
+
+    watch(this.i18n.global.locale, (locale) => syncDocumentLocale(locale), {
+      immediate: true,
+    })
 
     // Expose language loader globally
     window.loadLanguage = this.loadLanguage.bind(this)

--- a/resources/scripts/admin/components/dropdowns/CustomFieldIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/CustomFieldIndexDropdown.vue
@@ -11,7 +11,7 @@
     >
       <BaseIcon
         name="PencilIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.edit') }}
     </BaseDropdownItem>
@@ -23,7 +23,7 @@
     >
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/dropdowns/CustomerIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/CustomerIndexDropdown.vue
@@ -15,7 +15,7 @@
       <BaseDropdownItem>
         <BaseIcon
           name="PencilIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('general.edit') }}
       </BaseDropdownItem>
@@ -32,7 +32,7 @@
       <BaseDropdownItem>
         <BaseIcon
           name="EyeIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('general.view') }}
       </BaseDropdownItem>
@@ -45,7 +45,7 @@
     >
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/dropdowns/EstimateIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/EstimateIndexDropdown.vue
@@ -14,7 +14,7 @@
     >
       <BaseIcon
         name="LinkIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.copy_pdf_url') }}
     </BaseDropdownItem>
@@ -27,7 +27,7 @@
       <BaseDropdownItem>
         <BaseIcon
           name="PencilIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('general.edit') }}
       </BaseDropdownItem>
@@ -40,7 +40,7 @@
     >
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>
@@ -56,7 +56,7 @@
       <BaseDropdownItem>
         <BaseIcon
           name="EyeIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('general.view') }}
       </BaseDropdownItem>
@@ -69,7 +69,7 @@
     >
       <BaseIcon
         name="DocumentTextIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('estimates.clone_estimate') }}
     </BaseDropdownItem>
@@ -81,7 +81,7 @@
     >
       <BaseIcon
         name="DocumentTextIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('estimates.convert_to_invoice') }}
     </BaseDropdownItem>
@@ -97,7 +97,7 @@
     >
       <BaseIcon
         name="CheckCircleIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('estimates.mark_as_sent') }}
     </BaseDropdownItem>
@@ -113,7 +113,7 @@
     >
       <BaseIcon
         name="PaperAirplaneIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('estimates.send_estimate') }}
     </BaseDropdownItem>
@@ -122,7 +122,7 @@
     <BaseDropdownItem v-if="canResendEstimate(row)" @click="sendEstimate(row)">
       <BaseIcon
         name="PaperAirplaneIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('estimates.resend_estimate') }}
     </BaseDropdownItem>
@@ -137,7 +137,7 @@
     >
       <BaseIcon
         name="CheckCircleIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('estimates.mark_as_accepted') }}
     </BaseDropdownItem>
@@ -152,7 +152,7 @@
     >
       <BaseIcon
         name="XCircleIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('estimates.mark_as_rejected') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/dropdowns/ExpenseCategoryIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/ExpenseCategoryIndexDropdown.vue
@@ -17,7 +17,7 @@
     >
       <BaseIcon
         name="PencilIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.edit') }}
     </BaseDropdownItem>
@@ -29,7 +29,7 @@
     >
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/dropdowns/ExpenseIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/ExpenseIndexDropdown.vue
@@ -15,7 +15,7 @@
       <BaseDropdownItem>
         <BaseIcon
           name="PencilIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('general.edit') }}
       </BaseDropdownItem>
@@ -28,7 +28,7 @@
     >
       <BaseIcon
         name="DocumentDuplicateIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('expenses.duplicate_expense') }}
     </BaseDropdownItem>
@@ -40,7 +40,7 @@
     >
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/dropdowns/InvoiceIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/InvoiceIndexDropdown.vue
@@ -15,7 +15,7 @@
       <BaseDropdownItem v-show="row.allow_edit">
         <BaseIcon
           name="PencilIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('general.edit') }}
       </BaseDropdownItem>
@@ -25,7 +25,7 @@
     <BaseDropdownItem v-if="route.name === 'invoices.view'" @click="copyPdfUrl">
       <BaseIcon
         name="LinkIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.copy_pdf_url') }}
     </BaseDropdownItem>
@@ -41,7 +41,7 @@
       <BaseDropdownItem>
         <BaseIcon
           name="EyeIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('general.view') }}
       </BaseDropdownItem>
@@ -51,7 +51,7 @@
     <BaseDropdownItem v-if="canSendInvoice(row)" @click="sendInvoice(row)">
       <BaseIcon
         name="PaperAirplaneIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('invoices.send_invoice') }}
     </BaseDropdownItem>
@@ -60,7 +60,7 @@
     <BaseDropdownItem v-if="canReSendInvoice(row)" @click="sendInvoice(row)">
       <BaseIcon
         name="PaperAirplaneIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('invoices.resend_invoice') }}
     </BaseDropdownItem>
@@ -72,7 +72,7 @@
       >
         <BaseIcon
           name="CreditCardIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('invoices.record_payment') }}
       </BaseDropdownItem>
@@ -82,7 +82,7 @@
     <BaseDropdownItem v-if="canSendInvoice(row)" @click="onMarkAsSent(row.id)">
       <BaseIcon
         name="CheckCircleIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('invoices.mark_as_sent') }}
     </BaseDropdownItem>
@@ -94,7 +94,7 @@
     >
       <BaseIcon
         name="DocumentTextIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('invoices.clone_invoice') }}
     </BaseDropdownItem>
@@ -106,7 +106,7 @@
     >
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/dropdowns/ItemIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/ItemIndexDropdown.vue
@@ -15,7 +15,7 @@
       <BaseDropdownItem>
         <BaseIcon
           name="PencilIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('general.edit') }}
       </BaseDropdownItem>
@@ -28,7 +28,7 @@
     >
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/dropdowns/NoteIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/NoteIndexDropdown.vue
@@ -14,7 +14,7 @@
     >
       <BaseIcon
         name="PencilIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.edit') }}
     </BaseDropdownItem>
@@ -26,7 +26,7 @@
     >
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/dropdowns/PaymentIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/PaymentIndexDropdown.vue
@@ -18,7 +18,7 @@
     >
       <BaseIcon
         name="LinkIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.copy_pdf_url') }}
     </BaseDropdown-item>
@@ -31,7 +31,7 @@
       <BaseDropdownItem>
         <BaseIcon
           name="PencilIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('general.edit') }}
       </BaseDropdownItem>
@@ -48,7 +48,7 @@
       <BaseDropdownItem>
         <BaseIcon
           name="EyeIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('general.view') }}
       </BaseDropdownItem>
@@ -65,7 +65,7 @@
     >
       <BaseIcon
         name="PaperAirplaneIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('payments.send_payment') }}
     </BaseDropdownItem>
@@ -77,7 +77,7 @@
     >
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/dropdowns/PaymentModeIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/PaymentModeIndexDropdown.vue
@@ -11,7 +11,7 @@
     <BaseDropdownItem @click="editPaymentMode(row.id)">
       <BaseIcon
         name="PencilIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.edit') }}
     </BaseDropdownItem>
@@ -20,7 +20,7 @@
     <BaseDropdownItem @click="removePaymentMode(row.id)">
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/dropdowns/RecurringInvoiceIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/RecurringInvoiceIndexDropdown.vue
@@ -18,7 +18,7 @@
       <BaseDropdownItem>
         <BaseIcon
           name="PencilIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('general.edit') }}
       </BaseDropdownItem>
@@ -35,7 +35,7 @@
       <BaseDropdownItem>
         <BaseIcon
           name="EyeIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('general.view') }}
       </BaseDropdownItem>
@@ -48,7 +48,7 @@
     >
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/dropdowns/RoleIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/RoleIndexDropdown.vue
@@ -14,7 +14,7 @@
     >
       <BaseIcon
         name="PencilIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.edit') }}
     </BaseDropdownItem>
@@ -26,7 +26,7 @@
     >
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/dropdowns/TaxTypeIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/TaxTypeIndexDropdown.vue
@@ -14,7 +14,7 @@
     >
       <BaseIcon
         name="PencilIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.edit') }}
     </BaseDropdownItem>
@@ -26,7 +26,7 @@
     >
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/dropdowns/UserIndexDropdown.vue
+++ b/resources/scripts/admin/components/dropdowns/UserIndexDropdown.vue
@@ -12,7 +12,7 @@
       <BaseDropdownItem>
         <BaseIcon
           name="PencilIcon"
-          class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+          class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
         />
         {{ $t('general.edit') }}
       </BaseDropdownItem>
@@ -22,7 +22,7 @@
     <BaseDropdownItem @click="removeUser(row.id)">
       <BaseIcon
         name="TrashIcon"
-        class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+        class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
       />
       {{ $t('general.delete') }}
     </BaseDropdownItem>

--- a/resources/scripts/admin/components/estimate-invoice-common/CreateItems.vue
+++ b/resources/scripts/admin/components/estimate-invoice-common/CreateItems.vue
@@ -171,7 +171,7 @@
     "
     @click="store.addItem"
   >
-    <BaseIcon name="PlusCircleIcon" class="mr-2" />
+    <BaseIcon name="PlusCircleIcon" class="me-2" />
     {{ $t('general.add_new_item') }}
   </div>
 </template>

--- a/resources/scripts/admin/layouts/LayoutBasic.vue
+++ b/resources/scripts/admin/layouts/LayoutBasic.vue
@@ -9,7 +9,7 @@
     <ExchangeRateBulkUpdateModal />
 
     <main
-      class="h-screen h-screen-ios overflow-y-auto md:pl-56 xl:pl-64 min-h-0"
+      class="h-screen h-screen-ios overflow-y-auto md:ps-56 xl:ps-64 min-h-0"
     >
       <div class="pt-16 pb-16">
         <router-view />

--- a/resources/scripts/admin/layouts/partials/TheSiteHeader.vue
+++ b/resources/scripts/admin/layouts/partials/TheSiteHeader.vue
@@ -3,7 +3,7 @@
     class="
       fixed
       top-0
-      left-0
+      inset-x-0
       z-20
       flex
       items-center
@@ -51,7 +51,7 @@
         border-0
         rounded
         cursor-pointer
-        md:hidden md:ml-0
+        md:hidden md:ms-0
         hover:bg-gray-100
       "
       @click.prevent="onToggle"
@@ -73,7 +73,7 @@
                 justify-center
                 w-8
                 h-8
-                ml-2
+                ms-2
                 text-sm text-black
                 bg-white
                 rounded
@@ -90,7 +90,7 @@
             >
               <BaseIcon
                 name="DocumentTextIcon"
-                class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+                class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
                 aria-hidden="true"
               />
               {{ $t('invoices.new_invoice') }}
@@ -102,7 +102,7 @@
             >
               <BaseIcon
                 name="DocumentIcon"
-                class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+                class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
                 aria-hidden="true"
               />
               {{ $t('estimates.new_estimate') }}
@@ -115,7 +115,7 @@
             >
               <BaseIcon
                 name="UserIcon"
-                class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+                class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
                 aria-hidden="true"
               />
               {{ $t('customers.new_customer') }}
@@ -124,7 +124,7 @@
         </BaseDropdown>
       </li>
 
-      <li class="ml-2">
+      <li class="ms-2">
         <GlobalSearchBar
           v-if="
             userStore.currentUser.is_owner ||
@@ -138,7 +138,7 @@
       </li>
 
       <!-- User Dropdown-->
-      <li class="relative block float-left ml-2">
+      <li class="relative block float-left ms-2">
         <BaseDropdown width-class="w-48">
           <template #activator>
             <img
@@ -151,7 +151,7 @@
             <BaseDropdownItem>
               <BaseIcon
                 name="CogIcon"
-                class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+                class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
                 aria-hidden="true"
               />
               {{ $t('navigation.settings') }}
@@ -161,7 +161,7 @@
           <BaseDropdownItem @click="logout">
             <BaseIcon
               name="ArrowRightOnRectangleIcon"
-              class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+              class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
               aria-hidden="true"
             />
             {{ $t('navigation.logout') }}

--- a/resources/scripts/admin/layouts/partials/TheSiteHeader.vue
+++ b/resources/scripts/admin/layouts/partials/TheSiteHeader.vue
@@ -73,7 +73,6 @@
                 justify-center
                 w-8
                 h-8
-                ms-2
                 text-sm text-black
                 bg-white
                 rounded
@@ -133,7 +132,7 @@
         />
       </li>
 
-      <li>
+      <li class="ms-2">
         <CompanySwitcher />
       </li>
 

--- a/resources/scripts/admin/layouts/partials/TheSiteSidebar.vue
+++ b/resources/scripts/admin/layouts/partials/TheSiteSidebar.vue
@@ -21,11 +21,11 @@
       <TransitionChild
         as="template"
         enter="transition ease-in-out duration-300"
-        enter-from="-translate-x-full"
+        enter-from="ltr:-translate-x-full rtl:translate-x-full"
         enter-to="translate-x-0"
         leave="transition ease-in-out duration-300"
         leave-from="translate-x-0"
-        leave-to="-translate-x-full"
+        leave-to="ltr:-translate-x-full rtl:translate-x-full"
       >
         <div class="relative flex flex-col flex-1 w-full max-w-xs bg-white">
           <TransitionChild
@@ -37,7 +37,7 @@
             leave-from="opacity-100"
             leave-to="opacity-0"
           >
-            <div class="absolute top-0 right-0 pt-2 -mr-12">
+            <div class="absolute top-0 inset-e-0 pt-2 -me-12">
               <button
                 class="
                   flex
@@ -45,7 +45,7 @@
                   justify-center
                   w-10
                   h-10
-                  ml-1
+                  ms-1
                   rounded-full
                   focus:outline-hidden
                   focus:ring-2
@@ -82,9 +82,9 @@
                 :to="item.link"
                 :class="[
                   hasActiveUrl(item.link)
-                    ? 'text-primary-500 border-l-primary-500 bg-gray-100 '
-                    : 'text-black border-l-transparent',
-                  'cursor-pointer px-0 pl-4 py-3 flex items-center border-l-4 border-solid text-sm not-italic font-medium',
+                    ? 'text-primary-500 border-s-primary-500 bg-gray-100 '
+                    : 'text-black border-s-transparent',
+                  'cursor-pointer px-0 ps-4 py-3 flex items-center border-s-4 border-solid text-sm not-italic font-medium',
                 ]"
                 @click="globalStore.setSidebarVisibility(false)"
               >
@@ -94,7 +94,7 @@
                     hasActiveUrl(item.link)
                       ? 'text-primary-500 '
                       : 'text-gray-400',
-                    'mr-4 shrink-0 h-5 w-5',
+                    'me-4 shrink-0 h-5 w-5',
                   ]"
                   @click="globalStore.setSidebarVisibility(false)"
                 />
@@ -119,9 +119,9 @@
       pb-32
       overflow-y-auto
       bg-white
-      border-r border-gray-200 border-solid
+      border-e border-gray-200 border-solid
       xl:w-64
-      md:fixed md:flex md:flex-col md:inset-y-0
+      md:fixed md:flex md:flex-col md:inset-y-0 md:inset-s-0
       pt-16
     "
   >
@@ -136,9 +136,9 @@
         :to="item.link"
         :class="[
           hasActiveUrl(item.link)
-            ? 'text-primary-500 border-l-primary-500 bg-gray-100 '
-            : 'text-black border-l-transparent',
-          'cursor-pointer px-0 pl-6 hover:bg-gray-50 py-3 group flex items-center border-l-4 border-solid text-sm not-italic font-medium',
+            ? 'text-primary-500 border-s-primary-500 bg-gray-100 '
+            : 'text-black border-s-transparent',
+          'cursor-pointer px-0 ps-6 hover:bg-gray-50 py-3 group flex items-center border-s-4 border-solid text-sm not-italic font-medium',
         ]"
       >
         <BaseIcon
@@ -147,7 +147,7 @@
             hasActiveUrl(item.link)
               ? 'text-primary-500 group-hover:text-primary-500 '
               : 'text-gray-400 group-hover:text-black',
-            'mr-4 shrink-0 h-5 w-5 ',
+            'me-4 shrink-0 h-5 w-5 ',
           ]"
         />
 

--- a/resources/scripts/admin/views/estimates/Index.vue
+++ b/resources/scripts/admin/views/estimates/Index.vue
@@ -34,7 +34,7 @@
           v-if="userStore.hasAbilities(abilities.CREATE_ESTIMATE)"
           to="estimates/create"
         >
-          <BaseButton variant="primary" class="ml-4">
+          <BaseButton variant="primary" class="ms-4">
             <template #left="slotProps">
               <BaseIcon name="PlusIcon" :class="slotProps.class" />
             </template>
@@ -178,7 +178,7 @@
         class="mt-10"
       >
         <template #header>
-          <div class="absolute items-center left-6 top-2.5 select-none">
+          <div class="absolute items-center inset-s-6 top-2.5 select-none">
             <BaseCheckbox
               v-model="estimateStore.selectAllField"
               variant="primary"

--- a/resources/scripts/admin/views/estimates/View.vue
+++ b/resources/scripts/admin/views/estimates/View.vue
@@ -1,9 +1,9 @@
 <template>
   <SendEstimateModal @update="updateSentEstimate" />
-  <BasePage v-if="estimateData" class="xl:pl-96 xl:ml-8">
+  <BasePage v-if="estimateData" class="xl:ps-96 xl:ms-8">
     <BasePageHeader :title="pageTitle">
       <template #actions>
-        <div class="mr-3 text-sm">
+        <div class="me-3 text-sm">
           <BaseButton
             v-if="
               estimateData.status === 'DRAFT' &&
@@ -31,7 +31,7 @@
           {{ $t('estimates.send_estimate') }}
         </BaseButton>
 
-        <EstimateDropDown class="ml-3" :row="estimateData" />
+        <EstimateDropDown class="ms-3" :row="estimateData" />
       </template>
     </BasePageHeader>
 
@@ -40,14 +40,14 @@
       class="
         fixed
         top-0
-        left-0
+        inset-s-0
         hidden
         h-full
         pt-16
         pb-[6.4rem]
-        ml-56
+        ms-56
         bg-white
-        xl:ml-64
+        xl:ms-64
         w-88
         xl:block
       "
@@ -72,18 +72,27 @@
             variant="gray"
             @input="onSearched()"
           >
+            <template #left>
+              <BaseIcon
+                name="MagnifyingGlassIcon"
+                class="hidden text-gray-400 rtl:block"
+              />
+            </template>
             <template #right>
-              <BaseIcon name="MagnifyingGlassIcon" class="text-gray-400" />
+              <BaseIcon
+                name="MagnifyingGlassIcon"
+                class="text-gray-400 rtl:hidden"
+              />
             </template>
           </BaseInput>
         </div>
 
-        <div class="flex mb-6 ml-3" role="group" aria-label="First group">
+        <div class="flex mb-6 ms-3" role="group" aria-label="First group">
           <BaseDropdown
-            class="ml-3"
+            class="ms-3"
             position="bottom-start"
             width-class="w-45"
-            position-class="left-0"
+            position-class="inset-s-0"
           >
             <template #activator>
               <BaseButton size="md" variant="gray">
@@ -147,7 +156,7 @@
             </BaseDropdownItem>
           </BaseDropdown>
 
-          <BaseButton class="ml-1" size="md" variant="gray" @click="sortData">
+          <BaseButton class="ms-1" size="md" variant="gray" @click="sortData">
             <BaseIcon v-if="getOrderBy" name="SortAscendingIcon" />
             <BaseIcon v-else name="SortDescendingIcon" />
           </BaseButton>
@@ -159,7 +168,7 @@
         class="
           h-full
           overflow-y-scroll
-          border-l border-gray-200 border-solid
+          border-s border-gray-200 border-solid
           base-scroll
         "
       >
@@ -169,9 +178,9 @@
             :id="'estimate-' + estimate.id"
             :to="`/admin/estimates/${estimate.id}/view`"
             :class="[
-              'flex justify-between side-estimate p-4 cursor-pointer hover:bg-gray-100 items-center border-l-4 border-l-transparent',
+              'flex justify-between side-estimate p-4 cursor-pointer hover:bg-gray-100 items-center border-s-4 border-s-transparent',
               {
-                'bg-gray-100 border-l-4 border-l-primary-500 border-solid':
+                'bg-gray-100 border-s-4 border-s-primary-500 border-solid':
                   hasActiveUrl(estimate.id),
               },
             ]"
@@ -181,7 +190,7 @@
               <BaseText
                 :text="estimate.customer.name"
                 class="
-                  pr-2
+                  pe-2
                   mb-2
                   text-sm
                   not-italic
@@ -226,7 +235,7 @@
                   not-italic
                   font-semibold
                   leading-8
-                  text-right text-gray-900
+                  text-end text-gray-900
                 "
               />
 
@@ -236,7 +245,7 @@
                   not-italic
                   font-normal
                   leading-5
-                  text-right text-gray-600
+                  text-end text-gray-600
                   est-date
                 "
               >

--- a/resources/scripts/admin/views/estimates/create/EstimateCreate.vue
+++ b/resources/scripts/admin/views/estimates/create/EstimateCreate.vue
@@ -42,7 +42,7 @@
             :to="`/estimates/pdf/${estimateStore.newEstimate.unique_hash}`"
             target="_blank"
           >
-            <BaseButton class="mr-3" variant="primary-outline" type="button">
+            <BaseButton class="me-3" variant="primary-outline" type="button">
               <span class="flex">
                 {{ $t('general.view_pdf') }}
               </span>

--- a/resources/scripts/admin/views/expenses/Index.vue
+++ b/resources/scripts/admin/views/expenses/Index.vue
@@ -28,7 +28,7 @@
 
         <BaseButton
           v-if="userStore.hasAbilities(abilities.CREATE_EXPENSE)"
-          class="ml-4"
+          class="ms-4"
           variant="primary"
           @click="$router.push('expenses/create')"
         >
@@ -151,7 +151,7 @@
       >
         <!-- Select All Checkbox -->
         <template #header>
-          <div class="absolute items-center left-6 top-2.5 select-none">
+          <div class="absolute items-center inset-s-6 top-2.5 select-none">
             <BaseCheckbox
               v-model="selectAllFieldStatus"
               variant="primary"

--- a/resources/scripts/admin/views/invoices/Index.vue
+++ b/resources/scripts/admin/views/invoices/Index.vue
@@ -28,7 +28,7 @@
           v-if="userStore.hasAbilities(abilities.CREATE_INVOICE)"
           to="invoices/create"
         >
-          <BaseButton variant="primary" class="ml-4">
+          <BaseButton variant="primary" class="ms-4">
             <template #left="slotProps">
               <BaseIcon name="PlusIcon" :class="slotProps.class" />
             </template>
@@ -177,7 +177,7 @@
       >
         <!-- Select All Checkbox -->
         <template #header>
-          <div class="absolute items-center left-6 top-2.5 select-none">
+          <div class="absolute items-center inset-s-6 top-2.5 select-none">
             <BaseCheckbox
               v-model="invoiceStore.selectAllField"
               variant="primary"

--- a/resources/scripts/admin/views/invoices/View.vue
+++ b/resources/scripts/admin/views/invoices/View.vue
@@ -231,10 +231,10 @@ onSearched = debounce(onSearched, 500)
 <template>
   <SendInvoiceModal @update="updateSentInvoice" />
 
-  <BasePage v-if="invoiceData" class="xl:pl-96 xl:ml-8">
+  <BasePage v-if="invoiceData" class="xl:ps-96 xl:ms-8">
     <BasePageHeader :title="pageTitle">
       <template #actions>
-        <div class="text-sm mr-3">
+        <div class="text-sm me-3">
           <BaseButton
             v-if="
               invoiceData.status === 'DRAFT' &&
@@ -277,7 +277,7 @@ onSearched = debounce(onSearched, 500)
 
         <!-- Invoice Dropdown  -->
         <InvoiceDropdown
-          class="ml-3"
+          class="ms-3"
           :row="invoiceData"
           :load-data="loadInvoices"
         />
@@ -289,14 +289,14 @@ onSearched = debounce(onSearched, 500)
       class="
         fixed
         top-0
-        left-0
+        inset-s-0
         hidden
         h-full
         pt-16
         pb-[6.4rem]
-        ml-56
+        ms-56
         bg-white
-        xl:ml-64
+        xl:ms-64
         w-88
         xl:block
       "
@@ -321,14 +321,23 @@ onSearched = debounce(onSearched, 500)
             variant="gray"
             @input="onSearched()"
           >
+            <template #left>
+              <BaseIcon
+                name="MagnifyingGlassIcon"
+                class="hidden h-5 text-gray-400 rtl:block"
+              />
+            </template>
             <template #right>
-              <BaseIcon name="MagnifyingGlassIcon" class="h-5 text-gray-400" />
+              <BaseIcon
+                name="MagnifyingGlassIcon"
+                class="h-5 text-gray-400 rtl:hidden"
+              />
             </template>
           </BaseInput>
         </div>
 
-        <div class="flex mb-6 ml-3" role="group" aria-label="First group">
-          <BaseDropdown class="ml-3" position="bottom-start">
+        <div class="flex mb-6 ms-3" role="group" aria-label="First group">
+          <BaseDropdown class="ms-3" position="bottom-start">
             <template #activator>
               <BaseButton size="md" variant="gray">
                 <BaseIcon name="FunnelIcon" />
@@ -390,7 +399,7 @@ onSearched = debounce(onSearched, 500)
             </BaseDropdownItem>
           </BaseDropdown>
 
-          <BaseButton class="ml-1" size="md" variant="gray" @click="sortData">
+          <BaseButton class="ms-1" size="md" variant="gray" @click="sortData">
             <BaseIcon v-if="getOrderBy" name="BarsArrowUpIcon" />
             <BaseIcon v-else name="BarsArrowDownIcon" />
           </BaseButton>
@@ -402,7 +411,7 @@ onSearched = debounce(onSearched, 500)
         class="
           h-full
           overflow-y-scroll
-          border-l border-gray-200 border-solid
+          border-s border-gray-200 border-solid
           base-scroll
         "
       >
@@ -412,9 +421,9 @@ onSearched = debounce(onSearched, 500)
             :id="'invoice-' + invoice.id"
             :to="`/admin/invoices/${invoice.id}/view`"
             :class="[
-              'flex justify-between side-invoice p-4 cursor-pointer hover:bg-gray-100 items-center border-l-4 border-l-transparent',
+              'flex justify-between side-invoice p-4 cursor-pointer hover:bg-gray-100 items-center border-s-4 border-s-transparent',
               {
-                'bg-gray-100 border-l-4 border-l-primary-500 border-solid':
+                'bg-gray-100 border-s-4 border-s-primary-500 border-solid':
                   hasActiveUrl(invoice.id),
               },
             ]"
@@ -424,7 +433,7 @@ onSearched = debounce(onSearched, 500)
               <BaseText
                 :text="invoice.customer.name"
                 class="
-                  pr-2
+                  pe-2
                   mb-2
                   text-sm
                   not-italic
@@ -465,7 +474,7 @@ onSearched = debounce(onSearched, 500)
                   not-italic
                   font-semibold
                   leading-8
-                  text-right text-gray-900
+                  text-end text-gray-900
                   block
                 "
                 :amount="invoice.total"
@@ -477,7 +486,7 @@ onSearched = debounce(onSearched, 500)
                   not-italic
                   font-normal
                   leading-5
-                  text-right text-gray-600
+                  text-end text-gray-600
                   est-date
                 "
               >

--- a/resources/scripts/admin/views/invoices/create/InvoiceCreate.vue
+++ b/resources/scripts/admin/views/invoices/create/InvoiceCreate.vue
@@ -42,7 +42,7 @@
             :to="`/invoices/pdf/${invoiceStore.newInvoice.unique_hash}`"
             target="_blank"
           >
-            <BaseButton class="mr-3" variant="primary-outline" type="button">
+            <BaseButton class="me-3" variant="primary-outline" type="button">
               <span class="flex">
                 {{ $t('general.view_pdf') }}
               </span>

--- a/resources/scripts/admin/views/items/Index.vue
+++ b/resources/scripts/admin/views/items/Index.vue
@@ -131,7 +131,7 @@
         class="mt-3"
       >
         <template #header>
-          <div class="absolute items-center left-6 top-2.5 select-none">
+          <div class="absolute items-center inset-s-6 top-2.5 select-none">
             <BaseCheckbox
               v-model="itemStore.selectAllField"
               variant="primary"

--- a/resources/scripts/admin/views/payments/Index.vue
+++ b/resources/scripts/admin/views/payments/Index.vue
@@ -28,7 +28,7 @@
         <BaseButton
           v-if="userStore.hasAbilities(abilities.CREATE_PAYMENT)"
           variant="primary"
-          class="ml-4"
+          class="ms-4"
           @click="$router.push('/admin/payments/create')"
         >
           <template #left="slotProps">
@@ -131,7 +131,7 @@
       >
         <!-- Select All Checkbox -->
         <template #header>
-          <div class="absolute items-center left-6 top-2.5 select-none">
+          <div class="absolute items-center inset-s-6 top-2.5 select-none">
             <BaseCheckbox
               v-model="selectAllFieldStatus"
               variant="primary"

--- a/resources/scripts/admin/views/payments/View.vue
+++ b/resources/scripts/admin/views/payments/View.vue
@@ -1,6 +1,6 @@
 <template>
   <SendPaymentModal />
-  <BasePage class="xl:pl-96">
+  <BasePage class="xl:ps-96">
     <BasePageHeader :title="pageTitle">
       <template #actions>
         <BaseButton
@@ -14,7 +14,7 @@
 
         <PaymentDropdown
           :content-loading="isFetching"
-          class="ml-3"
+          class="ms-3"
           :row="payment"
         />
       </template>
@@ -25,14 +25,14 @@
       class="
         fixed
         top-0
-        left-0
+        inset-s-0
         hidden
         h-full
         pt-16
         pb-[6rem]
-        ml-56
+        ms-56
         bg-white
-        xl:ml-64
+        xl:ms-64
         w-88
         xl:block
       "
@@ -54,14 +54,22 @@
           type="text"
           @input="onSearch"
         >
-          <BaseIcon name="MagnifyingGlassIcon" class="h-5" />
+          <template #left>
+            <BaseIcon
+              name="MagnifyingGlassIcon"
+              class="hidden h-5 rtl:block"
+            />
+          </template>
+          <template #right>
+            <BaseIcon name="MagnifyingGlassIcon" class="h-5 rtl:hidden" />
+          </template>
         </BaseInput>
 
-        <div class="flex ml-3" role="group" aria-label="First group">
+        <div class="flex ms-3" role="group" aria-label="First group">
           <BaseDropdown
             position="bottom-start"
             width-class="w-50"
-            position-class="left-0"
+            position-class="inset-s-0"
           >
             <template #activator>
               <BaseButton variant="gray">
@@ -130,7 +138,7 @@
             </div>
           </BaseDropdown>
 
-          <BaseButton class="ml-1" size="md" variant="gray" @click="sortData">
+          <BaseButton class="ms-1" size="md" variant="gray" @click="sortData">
             <BaseIcon v-if="getOrderBy" name="SortAscendingIcon" />
             <BaseIcon v-else name="SortDescendingIcon" />
           </BaseButton>
@@ -139,7 +147,7 @@
 
       <div
         ref="paymentListSection"
-        class="h-full overflow-y-scroll border-l border-gray-200 border-solid"
+        class="h-full overflow-y-scroll border-s border-gray-200 border-solid"
       >
         <div v-for="(payment, index) in paymentList" :key="index">
           <router-link
@@ -147,9 +155,9 @@
             :id="'payment-' + payment.id"
             :to="`/admin/payments/${payment.id}/view`"
             :class="[
-              'flex justify-between p-4 items-center cursor-pointer hover:bg-gray-100 border-l-4 border-l-transparent',
+              'flex justify-between p-4 items-center cursor-pointer hover:bg-gray-100 border-s-4 border-s-transparent',
               {
-                'bg-gray-100 border-l-4 border-l-primary-500 border-solid':
+                'bg-gray-100 border-s-4 border-s-primary-500 border-solid':
                   hasActiveUrl(payment.id),
               },
             ]"
@@ -159,7 +167,7 @@
               <BaseText
                 :text="payment?.customer?.name"
                 class="
-                  pr-2
+                  pe-2
                   mb-2
                   text-sm
                   not-italic
@@ -209,13 +217,13 @@
                   not-italic
                   font-semibold
                   leading-8
-                  text-right text-gray-900
+                  text-end text-gray-900
                 "
                 :amount="payment?.amount"
                 :currency="payment.customer?.currency"
               />
 
-              <div class="text-sm text-right text-gray-500 non-italic">
+              <div class="text-sm text-end text-gray-500 non-italic">
                 {{ payment.formatted_payment_date }}
               </div>
             </div>

--- a/resources/scripts/admin/views/recurring-invoices/Index.vue
+++ b/resources/scripts/admin/views/recurring-invoices/Index.vue
@@ -34,7 +34,7 @@
           v-if="userStore.hasAbilities(abilities.CREATE_RECURRING_INVOICE)"
           to="recurring-invoices/create"
         >
-          <BaseButton variant="primary" class="ml-4">
+          <BaseButton variant="primary" class="ms-4">
             <template #left="slotProps">
               <BaseIcon name="PlusIcon" :class="slotProps.class" />
             </template>
@@ -172,7 +172,7 @@
       >
         <!-- Select All Checkbox -->
         <template #header>
-          <div class="absolute items-center left-6 top-2.5 select-none">
+          <div class="absolute items-center inset-s-6 top-2.5 select-none">
             <BaseCheckbox
               v-model="recurringInvoiceStore.selectAllField"
               variant="primary"

--- a/resources/scripts/admin/views/recurring-invoices/View.vue
+++ b/resources/scripts/admin/views/recurring-invoices/View.vue
@@ -1,5 +1,5 @@
 <template>
-  <BasePage class="xl:pl-96">
+  <BasePage class="xl:ps-96">
     <BasePageHeader :title="pageTitle">
       <template #actions>
         <RecurringInvoiceIndexDropdown

--- a/resources/scripts/admin/views/recurring-invoices/create/RecurringInvoiceCreate.vue
+++ b/resources/scripts/admin/views/recurring-invoices/create/RecurringInvoiceCreate.vue
@@ -37,7 +37,7 @@
             <BaseButton
               v-if="$route.name === 'invoices.edit'"
               target="_blank"
-              class="mr-3"
+              class="me-3"
               variant="primary-outline"
               type="button"
             >

--- a/resources/scripts/admin/views/recurring-invoices/partials/RecurringInvoiceViewSidebar.vue
+++ b/resources/scripts/admin/views/recurring-invoices/partials/RecurringInvoiceViewSidebar.vue
@@ -142,14 +142,14 @@ onSearched = debounce(onSearched, 500)
     class="
       fixed
       top-0
-      left-0
+      inset-s-0
       hidden
       h-full
       pt-16
       pb-[6.4rem]
-      ml-56
+      ms-56
       bg-white
-      xl:ml-64
+      xl:ms-64
       w-88
       xl:block
     "
@@ -174,14 +174,23 @@ onSearched = debounce(onSearched, 500)
           variant="gray"
           @input="onSearched()"
         >
+          <template #left>
+            <BaseIcon
+              name="MagnifyingGlassIcon"
+              class="hidden h-5 text-gray-400 rtl:block"
+            />
+          </template>
           <template #right>
-            <BaseIcon name="MagnifyingGlassIcon" class="h-5 text-gray-400" />
+            <BaseIcon
+              name="MagnifyingGlassIcon"
+              class="h-5 text-gray-400 rtl:hidden"
+            />
           </template>
         </BaseInput>
       </div>
 
-      <div class="flex mb-6 ml-3" role="group" aria-label="First group">
-        <BaseDropdown class="ml-3" position="bottom-start">
+      <div class="flex mb-6 ms-3" role="group" aria-label="First group">
+        <BaseDropdown class="ms-3" position="bottom-start">
           <template #activator>
             <BaseButton size="md" variant="gray">
               <BaseIcon name="FunnelIcon" class="h-5" />
@@ -229,7 +238,7 @@ onSearched = debounce(onSearched, 500)
           </BaseDropdownItem>
         </BaseDropdown>
 
-        <BaseButton class="ml-1" size="md" variant="gray" @click="sortData">
+        <BaseButton class="ms-1" size="md" variant="gray" @click="sortData">
           <BaseIcon v-if="getOrderBy" name="SortAscendingIcon" class="h-5" />
           <BaseIcon v-else name="SortDescendingIcon" class="h-5" />
         </BaseButton>
@@ -241,7 +250,7 @@ onSearched = debounce(onSearched, 500)
       class="
         h-full
         overflow-y-scroll
-        border-l border-gray-200 border-solid
+        border-s border-gray-200 border-solid
         base-scroll
       "
     >
@@ -251,9 +260,9 @@ onSearched = debounce(onSearched, 500)
           :id="'recurring-invoice-' + invoice.id"
           :to="`/admin/recurring-invoices/${invoice.id}/view`"
           :class="[
-            'flex justify-between side-invoice p-4 cursor-pointer hover:bg-gray-100 items-center border-l-4 border-l-transparent',
+            'flex justify-between side-invoice p-4 cursor-pointer hover:bg-gray-100 items-center border-s-4 border-s-transparent',
             {
-              'bg-gray-100 border-l-4 border-l-primary-500 border-solid':
+              'bg-gray-100 border-s-4 border-s-primary-500 border-solid':
                 hasActiveUrl(invoice.id),
             },
           ]"
@@ -263,7 +272,7 @@ onSearched = debounce(onSearched, 500)
             <BaseText
               :text="invoice.customer.name"
               class="
-                pr-2
+                pe-2
                 mb-2
                 text-sm
                 not-italic
@@ -305,7 +314,7 @@ onSearched = debounce(onSearched, 500)
                 not-italic
                 font-semibold
                 leading-8
-                text-right text-gray-900
+                text-end text-gray-900
               "
               :amount="invoice.total"
               :currency="invoice.customer.currency"
@@ -317,7 +326,7 @@ onSearched = debounce(onSearched, 500)
                 not-italic
                 font-normal
                 leading-5
-                text-right text-gray-600
+                text-end text-gray-600
                 est-date
               "
             >

--- a/resources/scripts/components/CompanySwitcher.vue
+++ b/resources/scripts/components/CompanySwitcher.vue
@@ -10,7 +10,6 @@
         px-3
         h-8
         md:h-9
-        ml-2
         text-sm text-white
         bg-white/20
         rounded
@@ -24,7 +23,7 @@
       >
         {{ companyStore.selectedCompany.name }}
       </span>
-      <BaseIcon name="ChevronDownIcon" class="h-5 ml-1 text-white" />
+      <BaseIcon name="ChevronDownIcon" class="h-5 ms-1 text-white" />
     </div>
 
     <transition
@@ -37,7 +36,7 @@
     >
       <div
         v-if="isShow"
-        class="absolute right-0 mt-2 bg-white rounded-md shadow-lg"
+        class="absolute inset-e-0 mt-2 bg-white rounded-md shadow-lg"
       >
         <div
           class="
@@ -103,7 +102,7 @@
                       flex
                       items-center
                       justify-center
-                      mr-3
+                      me-3
                       overflow-hidden
                       text-base
                       font-semibold
@@ -139,7 +138,7 @@
             items-center
             justify-center
             p-4
-            pl-3
+            ps-3
             border-t-2 border-gray-100
             cursor-pointer
             text-primary-400
@@ -147,7 +146,7 @@
           "
           @click="addNewCompany"
         >
-          <BaseIcon name="PlusIcon" class="h-5 mr-2" />
+          <BaseIcon name="PlusIcon" class="h-5 me-2" />
 
           <span class="font-medium">
             {{ $t('company_switcher.add_new_company') }}

--- a/resources/scripts/components/GlobalSearchBar.vue
+++ b/resources/scripts/components/GlobalSearchBar.vue
@@ -9,10 +9,24 @@
         @input="onSearch"
       >
         <template #left>
-          <BaseIcon name="MagnifyingGlassIcon" class="text-gray-400" />
+          <BaseIcon
+            name="MagnifyingGlassIcon"
+            class="text-gray-400 rtl:hidden"
+          />
+          <SpinnerIcon
+            v-if="isSearching"
+            class="hidden h-5 text-primary-500 rtl:block"
+          />
         </template>
         <template #right>
-          <SpinnerIcon v-if="isSearching" class="h-5 text-primary-500" />
+          <SpinnerIcon
+            v-if="isSearching"
+            class="h-5 text-primary-500 rtl:hidden"
+          />
+          <BaseIcon
+            name="MagnifyingGlassIcon"
+            class="hidden text-gray-400 rtl:block"
+          />
         </template>
       </BaseInput>
     </div>
@@ -40,7 +54,7 @@
           absolute
           w-[300px]
           h-[200px]
-          right-0
+          inset-e-0
         "
       >
         <div
@@ -81,7 +95,7 @@
                     justify-center
                     w-9
                     h-9
-                    mr-3
+                    me-3
                     text-base
                     font-semibold
                     bg-gray-200
@@ -129,7 +143,7 @@
                     justify-center
                     w-9
                     h-9
-                    mr-3
+                    me-3
                     text-base
                     font-semibold
                     bg-gray-200

--- a/resources/scripts/components/base-select/BaseMultiselect.vue
+++ b/resources/scripts/components/base-select/BaseMultiselect.vue
@@ -437,7 +437,7 @@ export default {
       required: false,
       default: () => ({
         container:
-          'p-0 relative mx-auto w-full flex items-center justify-end box-border cursor-pointer border border-gray-200 rounded-md bg-white text-sm leading-snug outline-hidden max-h-10',
+          'p-0 relative mx-auto w-full flex items-center justify-end rtl:justify-start box-border cursor-pointer border border-gray-200 rounded-md bg-white text-sm leading-snug outline-hidden max-h-10',
         containerDisabled:
           'cursor-default bg-gray-200/50 !text-gray-400',
         containerOpen: '',
@@ -447,14 +447,14 @@ export default {
           'border-red-400 ring-red-400 focus:ring-red-400 focus:border-red-400',
         containerInvalidActive: 'ring-1 border-red-400 ring-red-400',
         singleLabel:
-          'flex items-center h-full absolute left-0 top-0 pointer-events-none bg-transparent leading-snug pl-3.5',
+          'flex items-center h-full absolute inset-s-0 top-0 pointer-events-none bg-transparent leading-snug ps-3.5 pe-10 rtl:ps-10 rtl:pe-3.5',
         multipleLabel:
-          'flex items-center h-full absolute left-0 top-0 pointer-events-none bg-transparent leading-snug pl-3.5',
+          'flex items-center h-full absolute inset-s-0 top-0 pointer-events-none bg-transparent leading-snug ps-3.5 pe-10 rtl:ps-10 rtl:pe-3.5',
         search:
-          'w-full absolute inset-0 outline-hidden appearance-none box-border border-0 text-sm font-sans bg-white rounded-md pl-3.5',
-        tags: 'grow shrink flex flex-wrap mt-1 pl-2',
-        tag: 'bg-primary-500 text-white text-sm font-semibold py-0.5 pl-2 rounded mr-1 mb-1 flex items-center whitespace-nowrap',
-        tagDisabled: 'pr-2 !bg-gray-400 text-white',
+          'w-full absolute inset-0 outline-hidden appearance-none box-border border-0 text-sm font-sans bg-white rounded-md ps-3.5 pe-10 rtl:ps-10 rtl:pe-3.5',
+        tags: 'grow shrink flex flex-wrap mt-1 ps-2',
+        tag: 'bg-primary-500 text-white text-sm font-semibold py-0.5 ps-2 rounded me-1 mb-1 flex items-center whitespace-nowrap',
+        tagDisabled: 'pe-2 !bg-gray-400 text-white',
         tagRemove:
           'flex items-center justify-center p-1 mx-0.5 rounded-xs hover:bg-black/10 group',
         tagRemoveIcon:
@@ -464,16 +464,16 @@ export default {
           'absolute inset-0 border-0 focus:outline-hidden !shadow-none !focus:shadow-none appearance-none p-0 text-sm font-sans box-border w-full',
         tagsSearchCopy: 'invisible whitespace-pre-wrap inline-block h-px',
         placeholder:
-          'flex items-center h-full absolute left-0 top-0 pointer-events-none bg-transparent leading-snug pl-3.5 text-gray-400 text-sm',
+          'flex items-center h-full absolute inset-s-0 top-0 pointer-events-none bg-transparent leading-snug ps-3.5 pe-10 rtl:ps-10 rtl:pe-3.5 text-gray-400 text-sm',
         caret:
-          'bg-multiselect-caret bg-center bg-no-repeat w-5 h-5 py-px box-content z-5 relative mr-1 opacity-40 shrink-0 grow-0 transition-transform',
+          'bg-multiselect-caret bg-center bg-no-repeat w-5 h-5 py-px box-content z-5 relative ms-1 opacity-40 shrink-0 grow-0 transition-transform',
         caretOpen: 'rotate-180 pointer-events-auto',
         clear:
-          'pr-3.5 relative z-10 opacity-40 transition duration-300 shrink-0 grow-0 flex hover:opacity-80',
+          'ps-3.5 relative z-10 opacity-40 transition duration-300 shrink-0 grow-0 flex hover:opacity-80',
         clearIcon:
           'bg-multiselect-remove bg-center bg-no-repeat w-2.5 h-4 py-px box-content inline-block',
         spinner:
-          'bg-multiselect-spinner bg-center bg-no-repeat w-4 h-4 z-10 mr-3.5 animate-spin shrink-0 grow-0',
+          'bg-multiselect-spinner bg-center bg-no-repeat w-4 h-4 z-10 ms-3.5 animate-spin shrink-0 grow-0',
         dropdown:
           'max-h-60 shadow-lg absolute -left-px -right-px -bottom-1 border border-gray-300 mt-1 overflow-y-auto z-50 bg-white flex flex-col rounded-md',
         dropdownTop:
@@ -484,7 +484,7 @@ export default {
         optionsTop: 'flex-col-reverse',
         group: 'p-0 m-0',
         groupLabel:
-          'flex text-sm box-border items-center justify-start text-left py-1 px-3 font-semibold bg-gray-200 cursor-default leading-normal',
+          'flex text-sm box-border items-center justify-start text-start py-1 px-3 font-semibold bg-gray-200 cursor-default leading-normal',
         groupLabelPointable: 'cursor-pointer',
         groupLabelPointed: 'bg-gray-300 text-gray-700',
         groupLabelSelected: 'bg-primary-600 text-white',
@@ -494,7 +494,7 @@ export default {
           'text-primary-100 bg-primary-600/50 cursor-not-allowed',
         groupOptions: 'p-0 m-0',
         option:
-          'flex items-center justify-start box-border text-left cursor-pointer text-sm leading-snug py-2 px-3',
+          'flex items-center justify-start box-border text-start cursor-pointer text-sm leading-snug py-2 px-3',
         optionPointed: 'text-gray-800 bg-gray-100',
         optionSelected: 'text-white bg-primary-500',
         optionDisabled: 'text-gray-300 cursor-not-allowed',

--- a/resources/scripts/components/base/BaseBreadcrumbItem.vue
+++ b/resources/scripts/components/base/BaseBreadcrumbItem.vue
@@ -1,9 +1,9 @@
 <template>
-  <li class="pr-2 text-sm">
+  <li class="pe-2 text-sm">
     <router-link
       class="
         m-0
-        mr-2
+        me-2
         text-sm
         font-medium
         leading-5

--- a/resources/scripts/components/base/BaseButton.vue
+++ b/resources/scripts/components/base/BaseButton.vue
@@ -102,9 +102,9 @@ const roundedClass = computed(() => {
 
 const iconLeftClass = computed(() => {
   return {
-    '-ml-0.5 mr-2 h-4 w-4': props.size == 'sm',
-    '-ml-1 mr-2 h-5 w-5': props.size === 'md',
-    '-ml-1 mr-3 h-5 w-5': props.size === 'lg' || props.size === 'xl',
+    '-ms-0.5 me-2 h-4 w-4': props.size == 'sm',
+    '-ms-1 me-2 h-5 w-5': props.size === 'md',
+    '-ms-1 me-3 h-5 w-5': props.size === 'lg' || props.size === 'xl',
   }
 })
 
@@ -119,9 +119,9 @@ const iconVariantClass = computed(() => {
 
 const iconRightClass = computed(() => {
   return {
-    'ml-2 -mr-0.5 h-4 w-4': props.size == 'sm',
-    'ml-2 -mr-1 h-5 w-5': props.size === 'md',
-    'ml-3 -mr-1 h-5 w-5': props.size === 'lg' || props.size === 'xl',
+    'ms-2 -me-0.5 h-4 w-4': props.size == 'sm',
+    'ms-2 -me-1 h-5 w-5': props.size === 'md',
+    'ms-3 -me-1 h-5 w-5': props.size === 'lg' || props.size === 'xl',
   }
 })
 </script>

--- a/resources/scripts/components/base/BaseCheckbox.vue
+++ b/resources/scripts/components/base/BaseCheckbox.vue
@@ -10,7 +10,7 @@
         :class="[checkboxClass, disabledClass]"
       />
     </div>
-    <div class="ml-3 text-sm">
+    <div class="ms-3 text-sm">
       <label
         v-if="label"
         :for="id"

--- a/resources/scripts/components/base/BaseCustomerSelectInput.vue
+++ b/resources/scripts/components/base/BaseCustomerSelectInput.vue
@@ -22,7 +22,7 @@
       >
         <BaseIcon
           name="UserPlusIcon"
-          class="h-4 mr-2 -ml-2 text-center text-primary-400"
+          class="h-4 me-2 -ms-2 text-center text-primary-400"
         />
 
         {{ $t('customers.add_new_customer') }}

--- a/resources/scripts/components/base/BaseCustomerSelectPopup.vue
+++ b/resources/scripts/components/base/BaseCustomerSelectPopup.vue
@@ -26,14 +26,14 @@
       <div class="flex relative justify-between mb-2">
         <BaseText
           :text="selectedCustomer.name"
-          class="flex-1 text-base font-medium text-left text-gray-900"
+          class="flex-1 text-base font-medium text-start text-gray-900"
         />
         <div class="flex">
           <a
             class="
               relative
               my-0
-              ml-6
+              ms-6
               text-sm
               font-medium
               cursor-pointer
@@ -43,7 +43,7 @@
             "
             @click.stop="editCustomer"
           >
-            <BaseIcon name="PencilIcon" class="text-gray-500 h-4 w-4 mr-1" />
+            <BaseIcon name="PencilIcon" class="text-gray-500 h-4 w-4 me-1" />
 
             {{ $t('general.edit') }}
           </a>
@@ -51,7 +51,7 @@
             class="
               relative
               my-0
-              ml-6
+              ms-6
               text-sm
               flex
               items-center
@@ -61,7 +61,7 @@
             "
             @click="resetSelectedCustomer"
           >
-            <BaseIcon name="XCircleIcon" class="text-gray-500 h-4 w-4 mr-1" />
+            <BaseIcon name="XCircleIcon" class="text-gray-500 h-4 w-4 me-1" />
             {{ $t('general.deselect') }}
           </a>
         </div>
@@ -73,7 +73,7 @@
               mb-1
               text-sm
               font-medium
-              text-left text-gray-400
+              text-start text-gray-400
               uppercase
               whitespace-nowrap
             "
@@ -83,7 +83,7 @@
 
           <div
             v-if="selectedCustomer.billing"
-            class="flex flex-col flex-1 p-0 text-left"
+            class="flex flex-col flex-1 p-0 text-start"
           >
             <label
               v-if="selectedCustomer.billing.name"
@@ -123,7 +123,7 @@
               mb-1
               text-sm
               font-medium
-              text-left text-gray-400
+              text-start text-gray-400
               uppercase
               whitespace-nowrap
             "
@@ -133,7 +133,7 @@
 
           <div
             v-if="selectedCustomer.shipping"
-            class="flex flex-col flex-1 p-0 text-left"
+            class="flex flex-col flex-1 p-0 text-start"
           >
             <label
               v-if="selectedCustomer.shipping.name"
@@ -201,7 +201,7 @@
               !w-10
               !h-10
               p-2
-              mr-5
+              me-5
               text-sm text-white
               bg-gray-200
               rounded-full
@@ -217,7 +217,7 @@
 
             <p
               v-if="valid.$error && valid.$errors[0].$message"
-              class="text-red-500 text-sm absolute right-3 bottom-3"
+              class="text-red-500 text-sm absolute inset-e-3 bottom-3"
             >
               {{ $t('estimates.errors.required') }}
             </p>
@@ -290,7 +290,7 @@
                       justify-center
                       w-10
                       h-10
-                      mr-4
+                      me-4
                       text-xl
                       font-semibold
                       leading-9
@@ -303,7 +303,7 @@
                     {{ initGenerator(customer.name) }}
                   </span>
 
-                  <div class="flex flex-col justify-center text-left">
+                  <div class="flex flex-col justify-center text-start">
                     <BaseText
                       v-if="customer.name"
                       :text="customer.name"
@@ -362,7 +362,7 @@
               <label
                 class="
                   m-0
-                  ml-3
+                  ms-3
                   text-sm
                   leading-none
                   cursor-pointer

--- a/resources/scripts/components/base/BaseDatePicker.vue
+++ b/resources/scripts/components/base/BaseDatePicker.vue
@@ -14,9 +14,10 @@
       fill="currentColor"
       class="
         absolute
+        inset-s-0
         w-4
         h-4
-        mx-2
+        ms-2
         my-2.5
         text-sm
         not-italic
@@ -121,7 +122,7 @@ const props = defineProps({
   defaultInputClass: {
     type: String,
     default:
-      'font-base pl-8 py-2 outline-hidden focus:ring-primary-400 focus:outline-hidden focus:border-primary-400 block w-full sm:text-sm border-gray-200 rounded-md text-black',
+      'font-base ps-8 py-2 outline-hidden focus:ring-primary-400 focus:outline-hidden focus:border-primary-400 block w-full sm:text-sm border-gray-200 rounded-md text-black',
   },
   time24hr: {
     type: Boolean,

--- a/resources/scripts/components/base/BaseItemSelect.vue
+++ b/resources/scripts/components/base/BaseItemSelect.vue
@@ -8,7 +8,7 @@
         flex
         items-center
         h-10
-        pl-2
+        ps-2
         bg-gray-200
         border border-gray-200 border-solid
         rounded
@@ -17,7 +17,7 @@
       {{ item.name }}
 
       <span
-        class="absolute text-gray-400 cursor-pointer top-[8px] right-[10px]"
+        class="absolute text-gray-400 cursor-pointer top-[8px] inset-e-[10px]"
         @click="deselectItem(index)"
       >
         <BaseIcon name="XCircleIcon" />
@@ -52,7 +52,7 @@
         >
           <BaseIcon
             name="PlusCircleIcon"
-            class="h-4 mr-2 -ml-2 text-center text-primary-400"
+            class="h-4 me-2 -ms-2 text-center text-primary-400"
           />
           {{ $t('general.add_new_item') }}
         </BaseSelectAction>

--- a/resources/scripts/components/list/BaseListItem.vue
+++ b/resources/scripts/components/list/BaseListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <router-link v-bind="$attrs" :class="containerClass">
-    <span v-if="hasIconSlot" class="mr-3">
+    <span v-if="hasIconSlot" class="me-3">
       <slot name="icon" />
     </span>
     <span>{{ title }}</span>
@@ -28,7 +28,7 @@ export default {
     },
   },
   setup(props, { slots }) {
-    const defaultClass = `cursor-pointer pb-2 pr-0 text-sm font-medium leading-5  flex items-center`
+    const defaultClass = `cursor-pointer pb-2 pe-0 text-sm font-medium leading-5 flex items-center`
     let hasIconSlot = computed(() => {
       return !!slots.icon
     })

--- a/resources/scripts/customer/layouts/partials/TheSiteFooter.vue
+++ b/resources/scripts/customer/layouts/partials/TheSiteFooter.vue
@@ -9,7 +9,7 @@
       w-full
       h-10
       py-2
-      pr-8
+      pe-8
       text-sm
       font-normal
       text-gray-700
@@ -20,7 +20,7 @@
     <a
       href="http://bytefury.com/"
       target="_blank"
-      class="pl-1 font-normal text-gray-900"
+      class="ps-1 font-normal text-gray-900"
       >Bytefury
     </a>
   </footer>

--- a/resources/scripts/customer/layouts/partials/TheSiteHeader.vue
+++ b/resources/scripts/customer/layouts/partials/TheSiteHeader.vue
@@ -2,7 +2,7 @@
   <Disclosure
     v-slot="{ open }"
     as="nav"
-    class="bg-white shadow-xs fixed top-0 left-0 z-20 w-full"
+    class="bg-white shadow-xs fixed top-0 inset-x-0 z-20 w-full"
   >
     <div class="mx-auto px-8">
       <div class="flex justify-between h-16 w-full">
@@ -26,7 +26,7 @@
               <img v-else :src="customerLogo" class="h-6" />
             </a>
           </div>
-          <div class="hidden sm:-my-px sm:ml-6 sm:flex sm:space-x-8">
+          <div class="hidden sm:-my-px sm:ms-6 sm:flex sm:gap-x-8">
             <router-link
               v-for="item in globalStore.mainMenu"
               :key="item.title"
@@ -42,7 +42,7 @@
             </router-link>
           </div>
         </div>
-        <div class="hidden sm:ml-6 sm:flex sm:items-center">
+        <div class="hidden sm:ms-6 sm:flex sm:items-center">
           <button
             type="button"
             class="
@@ -60,7 +60,7 @@
 
           <!-- Profile dropdown -->
 
-          <Menu as="div" class="ml-3 relative">
+          <Menu as="div" class="ms-3 relative">
             <BaseDropdown width-class="w-48">
               <template #activator>
                 <MenuButton
@@ -85,7 +85,7 @@
               <router-link :to="{ name: 'customer.profile' }">
                 <BaseDropdownItem>
                   <CogIcon
-                    class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+                    class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
                     aria-hidden="true"
                   />
                   {{ $t('navigation.settings') }}
@@ -94,7 +94,7 @@
 
               <BaseDropdownItem @click="logout">
                 <ArrowRightOnRectangleIcon
-                  class="w-5 h-5 mr-3 text-gray-400 group-hover:text-gray-500"
+                  class="w-5 h-5 me-3 text-gray-400 group-hover:text-gray-500"
                   aria-hidden="true"
                 />
                 {{ $t('navigation.logout') }}
@@ -102,7 +102,7 @@
             </BaseDropdown>
           </Menu>
         </div>
-        <div class="-mr-2 flex items-center sm:hidden">
+        <div class="-me-2 flex items-center sm:hidden">
           <!-- Mobile menu button -->
           <DisclosureButton
             class="
@@ -138,7 +138,7 @@
             hasActiveUrl(item.link)
               ? 'bg-primary-50 border-primary-500 text-primary-700'
               : 'border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800',
-            'block pl-3 pr-4 py-2 border-l-4 text-base font-medium',
+            'block ps-3 pe-4 py-2 border-s-4 text-base font-medium',
           ]"
           :aria-current="item.current ? 'page' : undefined"
           >{{ $t(item.title) }}
@@ -149,7 +149,7 @@
           <div class="shrink-0">
             <img class="h-10 w-10 rounded-full" :src="previewAvatar" alt="" />
           </div>
-          <div class="ml-3">
+          <div class="ms-3">
             <div class="text-base font-medium text-gray-800">
               {{ globalStore.currentUser.title }}
             </div>
@@ -160,7 +160,7 @@
           <button
             type="button"
             class="
-              ml-auto
+              ms-auto
               bg-white
               shrink-0
               p-1
@@ -183,7 +183,7 @@
               hasActiveUrl(item.link)
                 ? 'bg-primary-50 border-primary-500 text-primary-700'
                 : 'border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800',
-              'block pl-3 pr-4 py-2 border-l-4 text-base font-medium',
+              'block ps-3 pe-4 py-2 border-s-4 text-base font-medium',
             ]"
             >{{ $t(item.title) }}</router-link
           >

--- a/resources/scripts/customer/views/estimates/View.vue
+++ b/resources/scripts/customer/views/estimates/View.vue
@@ -1,8 +1,8 @@
 <template>
-  <BasePage class="xl:pl-96">
+  <BasePage class="xl:ps-96">
     <BasePageHeader :title="pageTitle.estimate_number">
       <template #actions>
-        <div class="mr-3 text-sm">
+        <div class="me-3 text-sm">
           <BaseButton
             v-if="estimateStore.selectedViewEstimate.status === 'DRAFT'"
             variant="primary"
@@ -11,7 +11,7 @@
             {{ $t('estimates.accept_estimate') }}
           </BaseButton>
         </div>
-        <div class="mr-3 text-sm">
+        <div class="me-3 text-sm">
           <BaseButton
             v-if="estimateStore.selectedViewEstimate.status === 'DRAFT'"
             variant="primary-outline"
@@ -25,7 +25,7 @@
 
     <!-- Sidebar -->
     <div
-      class="fixed top-0 left-0 hidden h-full pt-16 pb-4 bg-white w-88 xl:block"
+      class="fixed top-0 inset-s-0 hidden h-full pt-16 pb-4 bg-white w-88 xl:block"
     >
       <div
         class="
@@ -45,16 +45,25 @@
           variant="gray"
           @input="onSearch"
         >
+          <template #left>
+            <BaseIcon
+              name="MagnifyingGlassIcon"
+              class="hidden h-5 text-gray-400 rtl:block"
+            />
+          </template>
           <template #right>
-            <BaseIcon name="MagnifyingGlassIcon" class="h-5 text-gray-400" />
+            <BaseIcon
+              name="MagnifyingGlassIcon"
+              class="h-5 text-gray-400 rtl:hidden"
+            />
           </template>
         </BaseInput>
 
-        <div class="flex ml-3" role="group" aria-label="First group">
+        <div class="flex ms-3" role="group" aria-label="First group">
           <BaseDropdown
             position="bottom-start"
             width-class="w-50"
-            position-class="left-0"
+            position-class="inset-s-0"
           >
             <template #activator>
               <BaseButton variant="gray">
@@ -124,7 +133,7 @@
             </div>
           </BaseDropdown>
 
-          <BaseButton class="ml-1" variant="white" @click="sortData">
+          <BaseButton class="ms-1" variant="white" @click="sortData">
             <BaseIcon v-if="getOrderBy" name="SortAscendingIcon" class="h-5" />
             <BaseIcon v-else name="SortDescendingIcon" class="h-5" />
           </BaseButton>
@@ -136,7 +145,7 @@
           h-full
           pb-32
           overflow-y-scroll
-          border-l border-gray-200 border-solid
+          border-s border-gray-200 border-solid
           sw-scroll
         "
       >
@@ -146,9 +155,9 @@
           :key="index"
           :to="`/${globalStore.companySlug}/customer/estimates/${estimate.id}/view`"
           :class="[
-            'flex justify-between p-4 items-center cursor-pointer hover:bg-gray-100 border-l-4 border-l-transparent',
+            'flex justify-between p-4 items-center cursor-pointer hover:bg-gray-100 border-s-4 border-s-transparent',
             {
-              'bg-gray-100 border-l-4 border-l-primary-500 border-solid':
+              'bg-gray-100 border-s-4 border-s-primary-500 border-solid':
                 hasActiveUrl(estimate.id),
             },
           ]"
@@ -182,13 +191,13 @@
                 not-italic
                 font-semibold
                 leading-8
-                text-right text-gray-900
+                text-end text-gray-900
                 block
               "
               :amount="estimate.total"
               :currency="estimate.currency"
             />
-            <div class="text-sm text-right text-gray-500 non-italic">
+            <div class="text-sm text-end text-gray-500 non-italic">
               {{ estimate.formatted_estimate_date }}
             </div>
           </div>

--- a/resources/scripts/customer/views/invoices/View.vue
+++ b/resources/scripts/customer/views/invoices/View.vue
@@ -1,11 +1,11 @@
 <template>
-  <BasePage class="xl:pl-96">
+  <BasePage class="xl:ps-96">
     <BasePageHeader :title="pageTitle.invoice_number">
       <template #actions>
         <BaseButton
           :disabled="isSendingEmail"
           variant="primary-outline"
-          class="mr-2"
+          class="me-2"
           tag="a"
           :href="`/invoices/pdf/${invoice.unique_hash}`"
           download
@@ -31,7 +31,7 @@
 
     <!-- Sidebar -->
     <div
-      class="fixed top-0 left-0 hidden h-full pt-16 pb-4 bg-white w-88 xl:block"
+      class="fixed top-0 inset-s-0 hidden h-full pt-16 pb-4 bg-white w-88 xl:block"
     >
       <div
         class="
@@ -51,16 +51,25 @@
           variant="gray"
           @input="onSearch"
         >
+          <template #left>
+            <BaseIcon
+              name="MagnifyingGlassIcon"
+              class="hidden h-5 text-gray-400 rtl:block"
+            />
+          </template>
           <template #right>
-            <BaseIcon name="MagnifyingGlassIcon" class="h-5 text-gray-400" />
+            <BaseIcon
+              name="MagnifyingGlassIcon"
+              class="h-5 text-gray-400 rtl:hidden"
+            />
           </template>
         </BaseInput>
 
-        <div class="flex ml-3" role="group" aria-label="First group">
+        <div class="flex ms-3" role="group" aria-label="First group">
           <BaseDropdown
             position="bottom-start"
             width-class="w-50"
-            position-class="left-0"
+            position-class="inset-s-0"
           >
             <template #activator>
               <BaseButton variant="gray">
@@ -130,7 +139,7 @@
             </div>
           </BaseDropdown>
 
-          <BaseButton class="ml-1" variant="white" @click="sortData">
+          <BaseButton class="ms-1" variant="white" @click="sortData">
             <BaseIcon v-if="getOrderBy" name="SortAscendingIcon" class="h-5" />
             <BaseIcon v-else name="SortDescendingIcon" class="h-5" />
           </BaseButton>
@@ -142,7 +151,7 @@
           h-full
           pb-32
           overflow-y-scroll
-          border-l border-gray-200 border-solid
+          border-s border-gray-200 border-solid
           sw-scroll
         "
       >
@@ -152,9 +161,9 @@
           :key="index"
           :to="`/${globalStore.companySlug}/customer/invoices/${invoice.id}/view`"
           :class="[
-            'flex justify-between p-4 items-center cursor-pointer hover:bg-gray-100 border-l-4 border-l-transparent',
+            'flex justify-between p-4 items-center cursor-pointer hover:bg-gray-100 border-s-4 border-s-transparent',
             {
-              'bg-gray-100 border-l-4 border-l-primary-500 border-solid':
+              'bg-gray-100 border-s-4 border-s-primary-500 border-solid':
                 hasActiveUrl(invoice.id),
             },
           ]"
@@ -187,14 +196,14 @@
                 not-italic
                 font-semibold
                 leading-8
-                text-right text-gray-900
+                text-end text-gray-900
                 block
               "
               :amount="invoice.total"
               :currency="invoice.currency"
             />
 
-            <div class="text-sm text-right text-gray-500 non-italic">
+            <div class="text-sm text-end text-gray-500 non-italic">
               {{ invoice.formatted_invoice_date }}
             </div>
           </div>

--- a/resources/scripts/customer/views/payments/View.vue
+++ b/resources/scripts/customer/views/payments/View.vue
@@ -1,5 +1,5 @@
 <template>
-  <BasePage class="xl:pl-96">
+  <BasePage class="xl:ps-96">
     <BasePageHeader :title="pageTitle.payment_number">
       <template #actions>
         <BaseButton
@@ -19,7 +19,7 @@
 
     <!-- Sidebar -->
     <div
-      class="fixed top-0 left-0 hidden h-full pt-16 pb-4 bg-white w-88 xl:block"
+      class="fixed top-0 inset-s-0 hidden h-full pt-16 pb-4 bg-white w-88 xl:block"
     >
       <div
         class="
@@ -39,16 +39,25 @@
           variant="gray"
           @input="onSearch"
         >
+          <template #left>
+            <BaseIcon
+              name="MagnifyingGlassIcon"
+              class="hidden h-5 text-gray-400 rtl:block"
+            />
+          </template>
           <template #right>
-            <BaseIcon name="MagnifyingGlassIcon" class="h-5 text-gray-400" />
+            <BaseIcon
+              name="MagnifyingGlassIcon"
+              class="h-5 text-gray-400 rtl:hidden"
+            />
           </template>
         </BaseInput>
 
-        <div class="flex ml-3" role="group" aria-label="First group">
+        <div class="flex ms-3" role="group" aria-label="First group">
           <BaseDropdown
             position="bottom-start"
             width-class="w-50"
-            position-class="left-0"
+            position-class="inset-s-0"
           >
             <template #activator>
               <BaseButton variant="gray">
@@ -118,7 +127,7 @@
             </div>
           </BaseDropdown>
 
-          <BaseButton class="ml-1" variant="white" @click="sortData">
+          <BaseButton class="ms-1" variant="white" @click="sortData">
             <BaseIcon v-if="getOrderBy" name="SortAscendingIcon" class="h-5" />
             <BaseIcon v-else name="SortDescendingIcon" class="h-5" />
           </BaseButton>
@@ -130,7 +139,7 @@
           h-full
           pb-32
           overflow-y-scroll
-          border-l border-gray-200 border-solid
+          border-s border-gray-200 border-solid
           sw-scroll
         "
       >
@@ -140,9 +149,9 @@
           :key="index"
           :to="`/${globalStore.companySlug}/customer/payments/${payment.id}/view`"
           :class="[
-            'flex justify-between p-4 items-center cursor-pointer hover:bg-gray-100 border-l-4 border-l-transparent',
+            'flex justify-between p-4 items-center cursor-pointer hover:bg-gray-100 border-s-4 border-s-transparent',
             {
-              'bg-gray-100 border-l-4 border-l-primary-500 border-solid':
+              'bg-gray-100 border-s-4 border-s-primary-500 border-solid':
                 hasActiveUrl(payment.id),
             },
           ]"
@@ -172,14 +181,14 @@
                 not-italic
                 font-semibold
                 leading-8
-                text-right text-gray-900
+                text-end text-gray-900
                 block
               "
               :amount="payment.amount"
               :currency="payment.currency"
             />
 
-            <div class="text-sm text-right text-gray-500 non-italic">
+            <div class="text-sm text-end text-gray-500 non-italic">
               {{ payment.formatted_payment_date }}
             </div>
           </div>

--- a/resources/scripts/helpers/document-locale.js
+++ b/resources/scripts/helpers/document-locale.js
@@ -1,0 +1,19 @@
+const rtlLocales = new Set(['ar', 'fa'])
+
+export function getDocumentDirection(locale) {
+  const language = String(locale || 'en')
+    .toLowerCase()
+    .split(/[-_]/, 1)[0]
+
+  return rtlLocales.has(language) ? 'rtl' : 'ltr'
+}
+
+export function syncDocumentLocale(
+  locale,
+  documentElement = document.documentElement,
+) {
+  const normalizedLocale = String(locale || 'en').replaceAll('_', '-')
+
+  documentElement.lang = normalizedLocale
+  documentElement.dir = getDocumentDirection(normalizedLocale)
+}

--- a/tests/JavaScript/document-locale.test.js
+++ b/tests/JavaScript/document-locale.test.js
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  getDocumentDirection,
+  syncDocumentLocale,
+} from '../../resources/scripts/helpers/document-locale.js'
+
+test('returns RTL direction for supported RTL locales', () => {
+  assert.equal(getDocumentDirection('ar'), 'rtl')
+  assert.equal(getDocumentDirection('ar_LY'), 'rtl')
+  assert.equal(getDocumentDirection('fa'), 'rtl')
+})
+
+test('returns LTR direction for other locales', () => {
+  assert.equal(getDocumentDirection('en'), 'ltr')
+  assert.equal(getDocumentDirection('zh_CN'), 'ltr')
+})
+
+test('synchronizes document language and direction', () => {
+  const documentElement = {}
+
+  syncDocumentLocale('ar_LY', documentElement)
+
+  assert.deepEqual(documentElement, {
+    dir: 'rtl',
+    lang: 'ar-LY',
+  })
+})

--- a/tests/JavaScript/rtl-button-layout.test.js
+++ b/tests/JavaScript/rtl-button-layout.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+function readProjectFile(path) {
+  return readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8')
+}
+
+test('uses logical spacing for BaseButton icons', () => {
+  const baseButton = readProjectFile(
+    'resources/scripts/components/base/BaseButton.vue',
+  )
+
+  assert.match(baseButton, /-ms-1 me-2 h-5 w-5/)
+  assert.match(baseButton, /ms-2 -me-1 h-5 w-5/)
+  assert.doesNotMatch(baseButton, /-ml-1 mr-2 h-5 w-5/)
+  assert.doesNotMatch(baseButton, /ml-2 -mr-1 h-5 w-5/)
+})
+
+test('uses logical spacing between invoice action buttons', () => {
+  const invoiceIndex = readProjectFile(
+    'resources/scripts/admin/views/invoices/Index.vue',
+  )
+  const invoiceView = readProjectFile(
+    'resources/scripts/admin/views/invoices/View.vue',
+  )
+
+  assert.match(invoiceIndex, /class="ms-4"/)
+  assert.match(invoiceView, /class="text-sm me-3"/)
+  assert.match(invoiceView, /class="ms-3"/)
+})

--- a/tests/JavaScript/rtl-button-layout.test.js
+++ b/tests/JavaScript/rtl-button-layout.test.js
@@ -29,3 +29,18 @@ test('uses logical spacing between invoice action buttons', () => {
   assert.match(invoiceView, /class="text-sm me-3"/)
   assert.match(invoiceView, /class="ms-3"/)
 })
+
+test('uses logical spacing between document edit actions', () => {
+  const editViewPaths = [
+    'resources/scripts/admin/views/invoices/create/InvoiceCreate.vue',
+    'resources/scripts/admin/views/estimates/create/EstimateCreate.vue',
+    'resources/scripts/admin/views/recurring-invoices/create/RecurringInvoiceCreate.vue',
+  ]
+
+  for (const path of editViewPaths) {
+    const editView = readProjectFile(path)
+
+    assert.match(editView, /class="me-3"/, path)
+    assert.doesNotMatch(editView, /class="mr-3"/, path)
+  }
+})

--- a/tests/JavaScript/rtl-invoice-layout.test.js
+++ b/tests/JavaScript/rtl-invoice-layout.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const invoiceView = readFileSync(
+  new URL(
+    '../../resources/scripts/admin/views/invoices/View.vue',
+    import.meta.url,
+  ),
+  'utf8',
+)
+
+test('positions the admin invoice viewer with logical RTL-aware offsets', () => {
+  assert.match(invoiceView, /class="xl:ps-96 xl:ms-8"/)
+  assert.match(invoiceView, /\binset-s-0\b/)
+  assert.match(invoiceView, /\bms-56\b/)
+  assert.match(invoiceView, /\bxl:ms-64\b/)
+
+  assert.doesNotMatch(invoiceView, /\bxl:pl-96\b/)
+  assert.doesNotMatch(invoiceView, /\bxl:ml-8\b/)
+  assert.doesNotMatch(invoiceView, /\bleft-0\b/)
+  assert.doesNotMatch(invoiceView, /\bml-56\b/)
+  assert.doesNotMatch(invoiceView, /\bxl:ml-64\b/)
+})

--- a/tests/JavaScript/rtl-layout-components.test.js
+++ b/tests/JavaScript/rtl-layout-components.test.js
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync } from 'node:fs'
+import test from 'node:test'
+
+function readProjectFile(path) {
+  return readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8')
+}
+
+const documentViewPaths = [
+  'resources/scripts/admin/views/invoices/View.vue',
+  'resources/scripts/admin/views/estimates/View.vue',
+  'resources/scripts/admin/views/payments/View.vue',
+  'resources/scripts/admin/views/recurring-invoices/partials/RecurringInvoiceViewSidebar.vue',
+  'resources/scripts/customer/views/invoices/View.vue',
+  'resources/scripts/customer/views/estimates/View.vue',
+  'resources/scripts/customer/views/payments/View.vue',
+]
+
+const selectableIndexPaths = [
+  'resources/scripts/admin/views/invoices/Index.vue',
+  'resources/scripts/admin/views/estimates/Index.vue',
+  'resources/scripts/admin/views/items/Index.vue',
+  'resources/scripts/admin/views/payments/Index.vue',
+  'resources/scripts/admin/views/recurring-invoices/Index.vue',
+  'resources/scripts/admin/views/expenses/Index.vue',
+]
+
+test('uses logical positioning in document sidebars', () => {
+  for (const path of documentViewPaths) {
+    const view = readProjectFile(path)
+
+    assert.match(view, /\binset-s-0\b/, path)
+    assert.match(view, /\bborder-s(?:-4)?\b/, path)
+    assert.doesNotMatch(view, /\bleft-0\b/, path)
+    assert.doesNotMatch(view, /\bborder-l(?:-4)?\b/, path)
+    assert.doesNotMatch(view, /\btext-right\b/, path)
+  }
+})
+
+test('mirrors document search icons without changing BaseInput globally', () => {
+  for (const path of documentViewPaths) {
+    const view = readProjectFile(path)
+
+    assert.match(view, /rtl:block/, path)
+    assert.match(view, /rtl:hidden/, path)
+  }
+})
+
+test('uses logical spacing in shared header and navigation components', () => {
+  const siteHeader = readProjectFile(
+    'resources/scripts/admin/layouts/partials/TheSiteHeader.vue',
+  )
+  const companySwitcher = readProjectFile(
+    'resources/scripts/components/CompanySwitcher.vue',
+  )
+  const globalSearch = readProjectFile(
+    'resources/scripts/components/GlobalSearchBar.vue',
+  )
+  const listItem = readProjectFile(
+    'resources/scripts/components/list/BaseListItem.vue',
+  )
+  const breadcrumbItem = readProjectFile(
+    'resources/scripts/components/base/BaseBreadcrumbItem.vue',
+  )
+
+  assert.equal(siteHeader.match(/class="ms-2"/g)?.length, 2)
+  assert.match(siteHeader, /float-left ms-2/)
+  assert.match(companySwitcher, /\binset-e-0\b/)
+  assert.match(globalSearch, /\binset-e-0\b/)
+  assert.match(listItem, /\bme-3\b/)
+  assert.match(breadcrumbItem, /\bme-2\b/)
+})
+
+test('positions selectable table controls at inline start', () => {
+  for (const path of selectableIndexPaths) {
+    const index = readProjectFile(path)
+
+    assert.match(index, /\binset-s-6\b/, path)
+    assert.doesNotMatch(index, /\bleft-6\b/, path)
+  }
+
+  const checkbox = readProjectFile(
+    'resources/scripts/components/base/BaseCheckbox.vue',
+  )
+
+  assert.match(checkbox, /\bms-3\b/)
+  assert.doesNotMatch(checkbox, /\bml-3\b/)
+})
+
+test('keeps multiselect controls and text clear in RTL', () => {
+  const multiselect = readProjectFile(
+    'resources/scripts/components/base-select/BaseMultiselect.vue',
+  )
+  const createItems = readProjectFile(
+    'resources/scripts/admin/components/estimate-invoice-common/CreateItems.vue',
+  )
+
+  assert.match(multiselect, /rtl:justify-start/)
+  assert.match(multiselect, /rtl:ps-10 rtl:pe-3\.5/)
+  assert.match(multiselect, /relative ms-1 opacity-40/)
+  assert.match(multiselect, /'ps-3\.5 relative z-10/)
+  assert.match(multiselect, /z-10 ms-3\.5 animate-spin/)
+  assert.match(multiselect, /\btext-start\b/)
+  assert.doesNotMatch(multiselect, /rounded-md pl-3\.5/)
+  assert.match(createItems, /class="me-2"/)
+  assert.doesNotMatch(createItems, /class="mr-2"/)
+})
+
+test('uses logical spacing throughout the customer selection popup', () => {
+  const customerSelect = readProjectFile(
+    'resources/scripts/components/base/BaseCustomerSelectPopup.vue',
+  )
+
+  assert.match(customerSelect, /\bms-3\b/)
+  assert.match(customerSelect, /\bme-4\b/)
+  assert.match(customerSelect, /\btext-start\b/)
+  assert.doesNotMatch(customerSelect, /\b(?:ml|mr)-(?:1|3|4|5|6)\b/)
+  assert.doesNotMatch(customerSelect, /\btext-left\b/)
+})
+
+test('keeps date picker text clear of its logical-start icon', () => {
+  const datePicker = readProjectFile(
+    'resources/scripts/components/base/BaseDatePicker.vue',
+  )
+
+  assert.match(datePicker, /\binset-s-0\b/)
+  assert.match(datePicker, /\bms-2\b/)
+  assert.match(datePicker, /font-base ps-8 py-2/)
+  assert.doesNotMatch(datePicker, /font-base pl-8 py-2/)
+})
+
+test('uses logical spacing between dropdown action icons and text', () => {
+  const dropdownDirectory = new URL(
+    '../../resources/scripts/admin/components/dropdowns/',
+    import.meta.url,
+  )
+
+  for (const fileName of readdirSync(dropdownDirectory)) {
+    if (!fileName.endsWith('.vue')) {
+      continue
+    }
+
+    const dropdown = readProjectFile(
+      `resources/scripts/admin/components/dropdowns/${fileName}`,
+    )
+
+    assert.doesNotMatch(dropdown, /\bmr-3\b/, fileName)
+  }
+})


### PR DESCRIPTION
## Pre-review request checklist

- [x] I have listed all changes in the `Changes` section.
- [x] I have tested my changes.
- [x] I have considered backwards compatibility.

## Changes

- Synchronize the document `lang` and `dir` attributes with the active Vue i18n locale.
- Use RTL direction for Arabic and Persian while retaining LTR for other locales.
- Replace physical left/right layout utilities with logical Tailwind utilities across headers, navigation, breadcrumbs, buttons, tables, dropdowns, date pickers, document viewers, and customer views.
- Prevent invoice, estimate, payment, and recurring-invoice sidebars from overlapping PDF viewers in RTL.
- Add dependency-free JavaScript regression tests for locale direction and RTL layout contracts.

## Why

Changing the language translated the interface but did not update the document direction. Some components also retained physical left/right spacing and positioning, causing overlaps and missing gaps in Arabic and Persian layouts.

## Impact and compatibility

LTR locales retain their existing direction and layout. RTL behavior is limited to Arabic and Persian. No dependencies or generated frontend assets are added.

## Validation

- Focused Node regression suite: 14 tests passed on this branch.
- Production build passed with Node 24 (`npm run build`).
- Manual RTL verification was performed with Arabic in the admin interface.

## Contribution note

This draft is offered as an optional community contribution. Code was generated by OpenAI Codex GPT-5.6 Sol with human oversight, review, and manual UI verification.
